### PR TITLE
Use micromamba

### DIFF
--- a/conda-store-server/Dockerfile
+++ b/conda-store-server/Dockerfile
@@ -1,4 +1,4 @@
-FROM condaforge/miniforge3:latest
+FROM mambaorg/micromamba
 
 
 RUN apt-get update \
@@ -10,7 +10,7 @@ RUN apt-get update \
 
 COPY environment.yaml /opt/conda-store-server/environment.yaml
 
-RUN conda env create -f /opt/conda-store-server/environment.yaml
+RUN micromamba create -y -f /opt/conda-store-server/environment.yaml
 
 COPY ./ /opt/conda-store-server/
 

--- a/conda-store/Dockerfile
+++ b/conda-store/Dockerfile
@@ -1,8 +1,8 @@
-FROM condaforge/miniforge3:latest
+FROM mambaorg/micromamba
 
 COPY environment.yaml /opt/conda-store/environment.yaml
 
-RUN conda env create -f /opt/conda-store/environment.yaml
+RUN micromamba create -y -f /opt/conda-store/environment.yaml
 
 COPY ./ /opt/conda-store/
 


### PR DESCRIPTION
Change base Docker image for `micromamba`, a lightweight `conda` drop-in replacement with faster solving times.