### PR TITLE
Support running `docker-compose` from archs != amd64

### DIFF
--- a/conda-store-server/Dockerfile
+++ b/conda-store-server/Dockerfile
@@ -1,4 +1,4 @@
-FROM condaforge/miniforge3:latest
+FROM --platform=linux/amd64 condaforge/miniforge3:latest
 
 
 RUN apt-get update \

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -9,6 +9,7 @@ services:
     volumes:
       - ./tests/assets/environments:/opt/environments:ro
       - ./data/conda-store:/data
+    platform: linux/amd64
     command: ["wait-for-it", "postgres:5432", '--', 'conda-store-server', 'build', '-p', '/opt/environments', '-e', '/data/envs', '-s', '/data/store', '--uid', '1000', '--gid', '100', '--permissions', '775', '--storage-backend', 's3']
     environment:
       CONDA_STORE_DB_URL: "postgresql+psycopg2://admin:password@postgres/conda-store"
@@ -21,6 +22,7 @@ services:
     depends_on:
       - "postgres"
       - "minio"
+    platform: linux/amd64
     command: ["wait-for-it", "postgres:5432", '--', 'conda-store-server', 'server', '-s', '/data/store', '--port', '5000']
     ports:
       - "5000:5000"

--- a/docs/development.md
+++ b/docs/development.md
@@ -15,8 +15,6 @@ To deploy `conda-store` run the following command
 docker-compose up --build
 ```
 
-Note: If you are not running this command from a Linux `amd64` system, make sure to export `DOCKER_DEFAULT_PLATFORM=linux/amd64` before.
-
 The following resources will be available:
   - conda-store web server running at http://localhost:5000
   - minio s3 running at http://localhost:9000 with username `admin` and password `password`
@@ -30,11 +28,11 @@ The following resources will be available:
 
 To enable the jupyterlab extension, ensure that an instance of `conda-store` is running.
 
-To build, activate the conda-store environemnt. 
+To build, activate the conda-store environemnt.
 
-Ensure that you are in the `extensions/` folder. 
+Ensure that you are in the `extensions/` folder.
 
-Then: 
+Then:
 
 ```shell
 pip install .
@@ -42,7 +40,7 @@ jupyter labextension develop . --overwrite
 jlpm build
 ```
 
-These commands should build the extension. Then, 
+These commands should build the extension. Then,
 
 `jupyter lab`
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -15,6 +15,8 @@ To deploy `conda-store` run the following command
 docker-compose up --build
 ```
 
+Note: If you are not running this command from a Linux `amd64` system, make sure to export `DOCKER_DEFAULT_PLATFORM=linux/amd64` before.
+
 The following resources will be available:
   - conda-store web server running at http://localhost:5000
   - minio s3 running at http://localhost:9000 with username `admin` and password `password`


### PR DESCRIPTION
The proposed changes are needed in an Apple Silicon MBP to emulate `amd64` archs for `conda-store-server`, due to the `fakechroot` dependency.

I have also put a [PR](https://github.com/conda-forge/fakechroot-feedstock/pull/3) to build `fakechroot` on `aarch64` (and `ppc64le`), which might allow us to avoid the emulation, but for now this is needed.