### PR TITLE
provide a docker-compose.yaml file for macos

### DIFF
--- a/conda-store-server/conda_store_server/build.py
+++ b/conda-store-server/conda_store_server/build.py
@@ -207,7 +207,8 @@ def conda_build(conda_store):
         build.size = utils.disk_usage(build_path)
 
         build_conda_pack(conda_store, build_path, build)
-        build_docker_image(conda_store, build_path, build)
+        if os.environ.get("CONDA_STORE_DO_NOT_CREATE_DOCKER_IMAGES") != "1":
+            build_docker_image(conda_store, build_path, build)
 
         set_build_completed(conda_store, build, output.encode("utf-8"), packages)
     except Exception as e:

--- a/docker-compose.macos.yaml
+++ b/docker-compose.macos.yaml
@@ -1,0 +1,66 @@
+version: "2"
+
+services:
+  conda-store-build:
+    build: conda-store-server
+    depends_on:
+      - "postgres"
+      - "minio"
+    volumes:
+      - ./tests/assets/environments:/opt/environments:ro
+      # - ./data/conda-store:/data
+    platform: linux/amd64
+    command: ["wait-for-it", "postgres:5432", '--', 'conda-store-server', 'build', '-p', '/opt/environments', '-e', '/data/envs', '-s', '/data/store', '--uid', '1000', '--gid', '100', '--permissions', '775', '--storage-backend', 's3']
+    environment:
+      CONDA_STORE_DB_URL: "postgresql+psycopg2://admin:password@postgres/conda-store"
+      CONDA_STORE_S3_ENDPOINT: minio:9000
+      CONDA_STORE_S3_ACCESS_KEY: admin
+      CONDA_STORE_S3_SECRET_KEY: password
+      CONDA_STORE_DO_NOT_CREATE_DOCKER_IMAGES: 1
+
+  conda-store-server:
+    build: conda-store-server
+    depends_on:
+      - "postgres"
+      - "minio"
+    platform: linux/amd64
+    command: ["wait-for-it", "postgres:5432", '--', 'conda-store-server', 'server', '-s', '/data/store', '--port', '5000']
+    ports:
+      - "5000:5000"
+    environment:
+      CONDA_STORE_DB_URL: "postgresql+psycopg2://admin:password@postgres/conda-store"
+      CONDA_STORE_S3_ENDPOINT: minio:9000
+      CONDA_STORE_S3_ACCESS_KEY: admin
+      CONDA_STORE_S3_SECRET_KEY: password
+
+  jupyterlab:
+    build: conda-store
+    command: /opt/conda/envs/conda-store/bin/jupyter lab --allow-root --ip=0.0.0.0 --NotebookApp.token=''
+    ports:
+      - "8888:8888"
+
+  minio:
+    image: minio/minio:RELEASE.2020-11-10T21-02-24Z
+    ports:
+      - "9000:9000"
+    entrypoint: sh
+    command: -c 'mkdir -p /data/conda-store && /usr/bin/minio server /data'
+    # volumes:
+    #   - ./data/minio:/data
+    environment:
+      MINIO_ACCESS_KEY: admin
+      MINIO_SECRET_KEY: password
+
+  postgres:
+    image: postgres:13
+    # TODO: need to properly fix this without this hack
+    # reuse sqlalchemy connections
+    command: postgres -c 'max_connections=200'
+    # volumes:
+    #   - ./data/postgresql:/var/lib/postgresql/data
+    ports:
+      - 5432:5432
+    environment:
+      POSTGRES_USER: admin
+      POSTGRES_PASSWORD: password
+      POSTGRES_DB: conda-store


### PR DESCRIPTION
Given the issues stated in #73, I am providing this workaround for now. It disables volumes and Docker image creation by setting an env var.

MacOS hosts need to run `docker-compose -f docker-compose.macos.yaml up --build` to deploy.