### PR TITLE
use conda api to obtain host platform

### DIFF
--- a/conda-store-server/Dockerfile
+++ b/conda-store-server/Dockerfile
@@ -2,7 +2,7 @@ FROM --platform=linux/amd64 mambaorg/micromamba
 
 RUN apt-get update \
     # https://docs.anaconda.org/anaconda/install/linux/#installing-on-linux
-    && apt-get install -y libgl1-mesa-glx libegl1-mesa libxrandr2 libxrandr2 libxss1 libxcursor1 libxcomposite1 libasound2 libxi6 libxtst6 \
+    && apt-get install -y libgl1-mesa-glx libegl1-mesa libxrandr2 libxss1 libxcursor1 libxcomposite1 libasound2 libxi6 libxtst6 \
     # needed only for development
     && apt-get install -y wait-for-it \
     && rm -rf /var/lib/apt/lists/*

--- a/conda-store-server/conda_store_server/api.py
+++ b/conda-store-server/conda_store_server/api.py
@@ -83,8 +83,7 @@ def get_build_lockfile(db, build_id):
 @EXPLICIT
 {1}
 """.format(
-        conda_platform(),
-        "\n".join(packages)
+        conda_platform(), "\n".join(packages)
     )
 
 

--- a/conda-store-server/conda_store_server/api.py
+++ b/conda-store-server/conda_store_server/api.py
@@ -5,7 +5,7 @@ import datetime
 from sqlalchemy import and_
 
 from conda_store_server import orm
-
+from .conda import conda_platform
 
 logger = logging.getLogger(__name__)
 
@@ -79,10 +79,11 @@ def get_build_lockfile(db, build_id):
         f"{row.channel}/{row.subdir}/{row.name}-{row.version}-{row.build}.tar.bz2#{row.md5}"
         for row in build.packages
     ]
-    return """#platform: linux-64
+    return """#platform: {0}
 @EXPLICIT
-{0}
+{1}
 """.format(
+        conda_platform(),
         "\n".join(packages)
     )
 

--- a/conda-store-server/conda_store_server/conda.py
+++ b/conda-store-server/conda_store_server/conda.py
@@ -30,9 +30,11 @@ def download_repodata(channel, architectures=None):
 
     A channel consists of several architectures: linux-32, linux-64,
     linux-aarch64, linux-armv6l, linux-armv7l, linux-ppc64le, noarch,
-    osx-64, win-32, win-64, zos-z (possibly others)
+    osx-64, win-32, win-64, zos-z (possibly others).
+
+    Check ``conda.base.constants.KNOWN_SUBDIRS`` for the full list.
     """
-    architectures = set(architectures or ["linux-64", "noarch"])
+    architectures = set(architectures or [conda_platform(), "noarch"])
 
     url = f"{channel}/channeldata.json"
     logger.info(f"downloading channeldata url={url}")
@@ -47,3 +49,13 @@ def download_repodata(channel, architectures=None):
         repodata[architecture] = requests.get(url).json()
 
     return repodata
+
+
+def conda_platform():
+    """
+    Return the platform (in ``conda`` style) the server is running on.
+
+    It will be one of the values in ``conda.base.constants.KNOWN_SUBDIRS``.
+    """
+    from conda.base.context import context
+    return context.subdir

--- a/conda-store-server/conda_store_server/conda.py
+++ b/conda-store-server/conda_store_server/conda.py
@@ -58,4 +58,5 @@ def conda_platform():
     It will be one of the values in ``conda.base.constants.KNOWN_SUBDIRS``.
     """
     from conda.base.context import context
+
     return context.subdir

--- a/conda-store-server/conda_store_server/orm.py
+++ b/conda-store-server/conda_store_server/orm.py
@@ -38,9 +38,7 @@ class BuildStatus(enum.Enum):
 
 
 class Specification(Base):
-    """The specifiction for a given conda environment
-
-    """
+    """The specifiction for a given conda environment"""
 
     __tablename__ = "specification"
 
@@ -75,9 +73,7 @@ build_conda_package = Table(
 
 
 class Build(Base):
-    """The state of a build of a given specification
-
-    """
+    """The state of a build of a given specification"""
 
     __tablename__ = "build"
 

--- a/conda-store-server/conda_store_server/server/templates/build.html
+++ b/conda-store-server/conda_store_server/server/templates/build.html
@@ -65,7 +65,7 @@
         <h3 class="card-title">Conda Environment Artifacts</h3>
     </div>
     <ul class="list-group list-group-flush">
-        <li class="list-group-item">Lockfile: <a href="/build/{{ build.id }}/lockfile/">conda-linux-64.lock</a></li>
+        <li class="list-group-item">Lockfile: <a href="/build/{{ build.id }}/lockfile/">conda-{{ platform }}.lock</a></li>
         <li class="list-group-item">Archive: <a href="/build/{{ build.id }}/archive/">environment.tar.gz</a></li>
     </ul>
 </div>

--- a/conda-store-server/conda_store_server/server/views/ui.py
+++ b/conda-store-server/conda_store_server/server/views/ui.py
@@ -4,6 +4,7 @@ import yaml
 
 from conda_store_server import api, schema
 from conda_store_server.server.utils import get_conda_store
+from conda_store_server.conda import conda_platform
 
 app_ui = Blueprint("ui", __name__, template_folder="templates")
 
@@ -78,7 +79,7 @@ def ui_get_specification(sha256):
 def ui_get_build(build_id):
     conda_store = get_conda_store()
     build = api.get_build(conda_store.db, build_id)
-    return render_template("build.html", build=build)
+    return render_template("build.html", build=build, platform=conda_platform())
 
 
 @app_ui.route("/build/<build_id>/logs/", methods=["GET"])

--- a/conda-store-server/setup.py
+++ b/conda-store-server/setup.py
@@ -3,57 +3,57 @@ import pathlib
 
 here = pathlib.Path(__file__).parent.resolve()
 
-long_description = (here / 'README.md').read_text(encoding='utf-8')
+long_description = (here / "README.md").read_text(encoding="utf-8")
 
 
 setup(
-    name='conda-store-server',
-    version='0.2.5',
-    description='Conda Environment Management, Builds, and Serve',
+    name="conda-store-server",
+    version="0.2.5",
+    description="Conda Environment Management, Builds, and Serve",
     long_description=long_description,
-    long_description_content_type='text/markdown',
-    url='https://github.com/Quansight/conda-store',
-    author='Christopher Ostrouchov',
-    author_email='chris.ostrouchov@gmail.com',
+    long_description_content_type="text/markdown",
+    url="https://github.com/Quansight/conda-store",
+    author="Christopher Ostrouchov",
+    author_email="chris.ostrouchov@gmail.com",
     classifiers=[
-        'Development Status :: 3 - Alpha',
-        'Intended Audience :: Developers',
-        'Topic :: Software Development :: Build Tools',
-        'License :: OSI Approved :: BSD License',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
-        'Programming Language :: Python :: 3 :: Only',
+        "Development Status :: 3 - Alpha",
+        "Intended Audience :: Developers",
+        "Topic :: Software Development :: Build Tools",
+        "License :: OSI Approved :: BSD License",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3 :: Only",
     ],
-    keywords='conda',
-    packages=find_packages(where='.'),
+    keywords="conda",
+    packages=find_packages(where="."),
     install_requires=[
-        'conda-docker',
-        'conda-pack',
-        'sqlalchemy',
-        'psycopg2',
-        'requests',
-        'flask',
-        'flask-cors',
-        'pyyaml',
-        'pydantic',
-        'minio',
+        "conda-docker",
+        "conda-pack",
+        "sqlalchemy",
+        "psycopg2",
+        "requests",
+        "flask",
+        "flask-cors",
+        "pyyaml",
+        "pydantic",
+        "minio",
     ],
     extras_require={
-        'dev': [
-            'pytest',
-            'pytest-mock',
-            'black==19.10b0',
-            'flake8',
-            'sphinx',
-            'recommonmark',
-            'sphinx_rtd_theme'
+        "dev": [
+            "pytest",
+            "pytest-mock",
+            "black==19.10b0",
+            "flake8",
+            "sphinx",
+            "recommonmark",
+            "sphinx_rtd_theme",
         ],
     },
     entry_points={
-        'console_scripts': [
-            'conda-store-server=conda_store_server.__main__:main',
+        "console_scripts": [
+            "conda-store-server=conda_store_server.__main__:main",
         ],
     },
     project_urls={

--- a/conda-store/Dockerfile
+++ b/conda-store/Dockerfile
@@ -1,5 +1,7 @@
 FROM mambaorg/micromamba
 
+USER root
+
 COPY environment.yaml /opt/conda-store/environment.yaml
 
 RUN micromamba create -y -f /opt/conda-store/environment.yaml


### PR DESCRIPTION
There were some instances of hardcoded `linux-64` strings as the default platform, which assumed that the server components were running on `linux/amd64` architectures. This is not necessarily true (e.g. MacOS M1 will report `aarch64`), so instead we use the Conda API to obtain the conda-style platform code.