### PR TITLE
test conda-store-build on docker

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -93,6 +93,12 @@ jobs:
   test-compose:
     name: Test conda-store-build on Docker
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        storage-backend:
+          - s3
+          - filesystem
+
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v2
@@ -107,5 +113,5 @@ jobs:
               --uid $(id -u) \
               --gid $(id -g) \
               --permissions 755 \
-              --storage-backend filesystem \
+              --storage-backend ${{ matrix.storage-backend }} \
               --poll-interval -1

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -99,6 +99,7 @@ jobs:
       - name: Run tests
         run: |
           docker-compose run conda-store-build \
+            wait-for-it postgres:5432 -- \
             conda-store-server build \
               -p /opt/environments \
               -e /data/envs \

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -89,3 +89,22 @@ jobs:
           pip install .
           jupyter labextension develop . --overwrite
           jlpm build
+
+  test-compose:
+    name: Test conda-store-build on Docker
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+      - name: Run tests
+        run: |
+          docker compose run conda-store-build \
+            conda-store-server build \
+              -p /opt/environments
+              -e /data/envs \
+              -s /data/store \
+              --uid $(id -u) \
+              --gid $(id -g) \
+              --permissions 755 \
+              --storage-backend s3 \
+              --poll-interval -1

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -42,6 +42,7 @@ jobs:
     name: 'Build docker images'
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         docker-image:
           - conda-store
@@ -94,6 +95,7 @@ jobs:
     name: Test conda-store-build on Docker, backend=${{ matrix.storage-backend }}
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         storage-backend:
           - s3

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -107,5 +107,5 @@ jobs:
               --uid $(id -u) \
               --gid $(id -g) \
               --permissions 755 \
-              --storage-backend s3 \
+              --storage-backend filesystem \
               --poll-interval -1

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -98,7 +98,7 @@ jobs:
         uses: actions/checkout@v2
       - name: Run tests
         run: |
-          docker compose run conda-store-build \
+          docker-compose run conda-store-build \
             conda-store-server build \
               -p /opt/environments \
               -e /data/envs \

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -98,7 +98,7 @@ jobs:
         uses: actions/checkout@v2
       - name: Run tests
         run: |
-          docker-compose run conda-store-build \
+          USER=root docker-compose run conda-store-build \
             conda-store-server build \
               -p /opt/environments \
               -e /data/envs \

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -98,7 +98,7 @@ jobs:
         uses: actions/checkout@v2
       - name: Run tests
         run: |
-          USER=root docker-compose run conda-store-build \
+          docker-compose run conda-store-build \
             conda-store-server build \
               -p /opt/environments \
               -e /data/envs \

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -100,7 +100,7 @@ jobs:
         run: |
           docker compose run conda-store-build \
             conda-store-server build \
-              -p /opt/environments
+              -p /opt/environments \
               -e /data/envs \
               -s /data/store \
               --uid $(id -u) \

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -91,7 +91,7 @@ jobs:
           jlpm build
 
   test-compose:
-    name: Test conda-store-build on Docker
+    name: Test conda-store-build on Docker, backend=${{ matrix.store-backend }}
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -91,7 +91,7 @@ jobs:
           jlpm build
 
   test-compose:
-    name: Test conda-store-build on Docker, backend=${{ matrix.store-backend }}
+    name: Test conda-store-build on Docker, backend=${{ matrix.storage-backend }}
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/conda-store-server/Dockerfile
+++ b/conda-store-server/Dockerfile
@@ -1,5 +1,7 @@
 FROM --platform=linux/amd64 condaforge/mambaforge
 
+USER root
+
 RUN apt-get update \
     # https://docs.anaconda.org/anaconda/install/linux/#installing-on-linux
     && apt-get install -y libgl1-mesa-glx libegl1-mesa libxrandr2 libxss1 libxcursor1 libxcomposite1 libasound2 libxi6 libxtst6 \

--- a/conda-store-server/conda_store_server/build.py
+++ b/conda-store-server/conda_store_server/build.py
@@ -183,7 +183,12 @@ def conda_build(conda_store, reschedule=True):
                             conda_store, build_path, tmp_environment_filename
                         )
                     except subprocess.CalledProcessError as e:
-                        set_build_failed(conda_store, build, e.output.encode("utf-8"), reschedule=reschedule)
+                        set_build_failed(
+                            conda_store,
+                            build,
+                            e.output.encode("utf-8"),
+                            reschedule=reschedule,
+                        )
                         return False
 
         utils.symlink(build_path, environment_path)
@@ -225,13 +230,23 @@ def conda_build(conda_store, reschedule=True):
         return True
     except Exception as e:
         logger.exception(e)
-        set_build_failed(conda_store, build, traceback.format_exc().encode("utf-8"), reschedule=reschedule)
+        set_build_failed(
+            conda_store,
+            build,
+            traceback.format_exc().encode("utf-8"),
+            reschedule=reschedule,
+        )
         return False
     except BaseException as e:
         logger.error(
             f"exception {e.__class__.__name__} caught causing build={build.id} to be rescheduled"
         )
-        set_build_failed(conda_store, build, traceback.format_exc().encode("utf-8"), reschedule=reschedule)
+        set_build_failed(
+            conda_store,
+            build,
+            traceback.format_exc().encode("utf-8"),
+            reschedule=reschedule,
+        )
         sys.exit(1)
 
 

--- a/conda-store-server/conda_store_server/cli.py
+++ b/conda-store-server/conda_store_server/cli.py
@@ -95,7 +95,8 @@ def cli_conda_store_build_command(
     poll_interval: int = typer.Option(
         10,
         "--poll-interval",
-        help="poll interval to check environment directory for new environments",
+        help="poll interval to check environment directory for new environments."
+             "If negative, it will exit after trying to build all environments.",
     ),
 ):
     conda_store = CondaStore(

--- a/conda-store-server/conda_store_server/cli.py
+++ b/conda-store-server/conda_store_server/cli.py
@@ -96,7 +96,7 @@ def cli_conda_store_build_command(
         10,
         "--poll-interval",
         help="poll interval to check environment directory for new environments."
-             "If negative, it will exit after trying to build all environments.",
+        "If negative, it will exit after trying to build all environments.",
     ),
 ):
     conda_store = CondaStore(

--- a/conda-store-server/conda_store_server/conda.py
+++ b/conda-store-server/conda_store_server/conda.py
@@ -21,9 +21,15 @@ def conda_list(prefix):
 
 
 def conda_pack(prefix, output):
+    import os
     import conda_pack
 
-    conda_pack.pack(prefix=str(prefix), output=str(output))
+    ignore = os.environ.get("CONDA_PACK_IGNORE_MISSING_FILES", "") == "1"
+    conda_pack.pack(
+        prefix=str(prefix),
+        output=str(output),
+        ignore_missing_files=ignore,
+    )
 
 
 def download_repodata(channel, architectures=None):

--- a/conda-store-server/conda_store_server/conda.py
+++ b/conda-store-server/conda_store_server/conda.py
@@ -26,9 +26,7 @@ def conda_pack(prefix, output):
 
     ignore = os.environ.get("CONDA_PACK_IGNORE_MISSING_FILES", "") == "1"
     conda_pack.pack(
-        prefix=str(prefix),
-        output=str(output),
-        ignore_missing_files=ignore,
+        prefix=str(prefix), output=str(output), ignore_missing_files=ignore,
     )
 
 

--- a/conda-store-server/conda_store_server/storage.py
+++ b/conda-store-server/conda_store_server/storage.py
@@ -59,7 +59,9 @@ class LocalStorage(Storage):
         self.base_url = base_url
 
     def fset(self, key, filename, content_type=None):
-        shutil.copyfile(filename, self.storage_path / key)
+        dest = self.storage_path / key
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copyfile(filename, dest)
 
     def set(self, key, value, content_type=None):
         with (self.storage_path / key).open("wb") as f:

--- a/conda-store-server/conda_store_server/storage.py
+++ b/conda-store-server/conda_store_server/storage.py
@@ -64,7 +64,9 @@ class LocalStorage(Storage):
         shutil.copyfile(filename, dest)
 
     def set(self, key, value, content_type=None):
-        with (self.storage_path / key).open("wb") as f:
+        dest = self.storage_path / key
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        with dest.open("wb") as f:
             f.write(value)
 
     def get_url(self, key):

--- a/conda-store-server/environment.yaml
+++ b/conda-store-server/environment.yaml
@@ -5,6 +5,7 @@ dependencies:
   # conda environment builds
   - conda-docker
   - conda-pack
+  - micromamba
   # web server
   - sqlalchemy
   - psycopg2

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -8,7 +8,7 @@ services:
       - "minio"
     volumes:
       - ./tests/assets/environments:/opt/environments:ro
-      - ./data/conda-store:/data
+      # - ./data/conda-store:/data
     platform: linux/amd64
     command: ["wait-for-it", "postgres:5432", '--', 'conda-store-server', 'build', '-p', '/opt/environments', '-e', '/data/envs', '-s', '/data/store', '--uid', '1000', '--gid', '100', '--permissions', '775', '--storage-backend', 's3']
     environment:
@@ -44,8 +44,8 @@ services:
       - "9000:9000"
     entrypoint: sh
     command: -c 'mkdir -p /data/conda-store && /usr/bin/minio server /data'
-    volumes:
-      - ./data/minio:/data
+    # volumes:
+      # - ./data/minio:/data
     environment:
       MINIO_ACCESS_KEY: admin
       MINIO_SECRET_KEY: password
@@ -55,8 +55,8 @@ services:
     # TODO: need to properly fix this without this hack
     # reuse sqlalchemy connections
     command: postgres -c 'max_connections=200'
-    volumes:
-      - ./data/postgresql:/var/lib/postgresql/data
+    # volumes:
+      # - ./data/postgresql:/var/lib/postgresql/data
     ports:
       - 5432:5432
     environment:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -8,7 +8,7 @@ services:
       - "minio"
     volumes:
       - ./tests/assets/environments:/opt/environments:ro
-      # - ./data/conda-store:/data
+      - ./data/conda-store:/data
     platform: linux/amd64
     command: ["wait-for-it", "postgres:5432", '--', 'conda-store-server', 'build', '-p', '/opt/environments', '-e', '/data/envs', '-s', '/data/store', '--uid', '1000', '--gid', '100', '--permissions', '775', '--storage-backend', 's3']
     environment:
@@ -44,8 +44,8 @@ services:
       - "9000:9000"
     entrypoint: sh
     command: -c 'mkdir -p /data/conda-store && /usr/bin/minio server /data'
-    # volumes:
-      # - ./data/minio:/data
+    volumes:
+      - ./data/minio:/data
     environment:
       MINIO_ACCESS_KEY: admin
       MINIO_SECRET_KEY: password
@@ -55,8 +55,8 @@ services:
     # TODO: need to properly fix this without this hack
     # reuse sqlalchemy connections
     command: postgres -c 'max_connections=200'
-    # volumes:
-      # - ./data/postgresql:/var/lib/postgresql/data
+    volumes:
+      - ./data/postgresql:/var/lib/postgresql/data
     ports:
       - 5432:5432
     environment:


### PR DESCRIPTION
Add a workflow entry so the Docker component for building environments can be tested in CI.

This needs a way to make `start_conda_build` behave like a one-shot function. I used `poll_interval` argument for this. If `n <= 0`, it will behave like one-shot. To provide a valid exit code, we keep track of the exit status of all attempted builds and disable the rescheduling after failures.