### PR TITLE
Adding prometheus metrics endpoint

### DIFF
--- a/conda-store-server/conda_store_server/api.py
+++ b/conda-store-server/conda_store_server/api.py
@@ -1,8 +1,7 @@
 import logging
-import math
 import datetime
 
-from sqlalchemy import and_
+from sqlalchemy import and_, func
 
 from conda_store_server import orm
 from .conda import conda_platform
@@ -94,20 +93,18 @@ def list_conda_packages(db, limit=25):
 def get_metrics(db):
     metrics = (
         db.query(
-            orm.CondaStoreConfiguration.free_storage.label("free"),
-            orm.CondaStoreConfiguration.total_storage.label("total"),
+            orm.CondaStoreConfiguration.free_storage.label("disk_free"),
+            orm.CondaStoreConfiguration.total_storage.label("disk_total"),
             orm.CondaStoreConfiguration.disk_usage,
         )
         .first()
         ._asdict()
     )
 
-    metrics["total_completed_builds"] = (
-        db.query(orm.Build)
-        .filter(orm.Build.status == orm.BuildStatus.COMPLETED)
-        .count()
-    )
-    metrics["total_environments"] = db.query(orm.Environment).count()
-    metrics["used"] = metrics["total"] - metrics["free"]
-    metrics["percent"] = math.ceil(metrics["used"] / metrics["total"] * 100)
+    query = (db.query(func.count(orm.Build.status), orm.Build.status)
+             .group_by(orm.Build.status))
+    for build_count, build_status_enum in query.all():
+        metrics[f"build_{build_status_enum.value.lower()}"] = build_count
+
+    metrics["environments"] = db.query(orm.Environment).count()
     return metrics

--- a/conda-store-server/conda_store_server/api.py
+++ b/conda-store-server/conda_store_server/api.py
@@ -101,8 +101,9 @@ def get_metrics(db):
         ._asdict()
     )
 
-    query = (db.query(func.count(orm.Build.status), orm.Build.status)
-             .group_by(orm.Build.status))
+    query = db.query(func.count(orm.Build.status), orm.Build.status).group_by(
+        orm.Build.status
+    )
     for build_count, build_status_enum in query.all():
         metrics[f"build_{build_status_enum.value.lower()}"] = build_count
 

--- a/conda-store-server/conda_store_server/server/__init__.py
+++ b/conda-store-server/conda_store_server/server/__init__.py
@@ -11,6 +11,7 @@ def start_app(
     disable_ui=False,
     disable_api=False,
     disable_registry=False,
+    disable_metrics=False,
     address="0.0.0.0",
     port=5000,
 ):
@@ -25,6 +26,9 @@ def start_app(
 
     if not disable_ui:
         app.register_blueprint(views.app_ui)
+
+    if not disable_metrics:
+        app.register_blueprint(views.app_metrics)
 
     @app.before_request
     def ensure_conda_store():

--- a/conda-store-server/conda_store_server/server/templates/home.html
+++ b/conda-store-server/conda_store_server/server/templates/home.html
@@ -20,23 +20,6 @@
 </div>
 {% endfor %}
 
-<div class="card my-2">
-    <div class="card-body">
-        <h3 class="card-title">Metrics</h3>
-    </div>
-    <div class="card-body">
-        <h4>Disk Usage: {{ metrics.used | filesizeformat }} / {{ metrics.total | filesizeformat }}</h4>
-
-        <div class="progress">
-            <div class="progress-bar" role="progressbar" style="width: {{ metrics.percent }}%;" aria-valuenow="{{ metrics.percent }}" aria-valuemin="0" aria-valuemax="100">{{ metrics.percent }}%</div>
-        </div>
-
-        <h4>Conda Store Usage: {{ metrics.disk_usage | filesizeformat }}</h4>
-        <h4>Number Environments: {{ metrics.total_environments }}</h4>
-        <h4>Number Cached Builds: {{ metrics.total_completed_builds }}</h4>
-    </div>
-</div>
-
 <script>
  function setClipboard(value) {
      var tempInput = document.createElement("input");

--- a/conda-store-server/conda_store_server/server/views/__init__.py
+++ b/conda-store-server/conda_store_server/server/views/__init__.py
@@ -1,3 +1,4 @@
 from conda_store_server.server.views.api import app_api  # noqa
 from conda_store_server.server.views.registry import app_registry  # noqa
 from conda_store_server.server.views.ui import app_ui  # noqa
+from conda_store_server.server.views.metrics import app_metrics  # noqa

--- a/conda-store-server/conda_store_server/server/views/metrics.py
+++ b/conda-store-server/conda_store_server/server/views/metrics.py
@@ -11,6 +11,8 @@ app_metrics = Blueprint("metrics", __name__)
 def prometheus_metrics():
     conda_store = get_conda_store()
     metrics = api.get_metrics(conda_store.db)
-    response = make_response('\n'.join(f'conda_store_{key} {value}' for key, value in metrics.items()))
+    response = make_response(
+        "\n".join(f"conda_store_{key} {value}" for key, value in metrics.items())
+    )
     response.mimetype = "text/plain"
     return response

--- a/conda-store-server/conda_store_server/server/views/metrics.py
+++ b/conda-store-server/conda_store_server/server/views/metrics.py
@@ -1,0 +1,16 @@
+from flask import Blueprint, make_response
+
+from conda_store_server import api
+from conda_store_server.server.utils import get_conda_store
+
+
+app_metrics = Blueprint("metrics", __name__)
+
+
+@app_metrics.route("/metrics")
+def prometheus_metrics():
+    conda_store = get_conda_store()
+    metrics = api.get_metrics(conda_store.db)
+    response = make_response('\n'.join(f'conda_store_{key} {value}' for key, value in metrics.items()))
+    response.mimetype = "text/plain"
+    return response

--- a/conda-store-server/conda_store_server/server/views/ui.py
+++ b/conda-store-server/conda_store_server/server/views/ui.py
@@ -40,7 +40,6 @@ def ui_list_environments():
     return render_template(
         "home.html",
         environments=api.list_environments(conda_store.db),
-        metrics=api.get_metrics(conda_store.db),
     )
 
 

--- a/conda-store-server/environment-dev.yaml
+++ b/conda-store-server/environment-dev.yaml
@@ -1,0 +1,28 @@
+name: conda-store-server-dev
+channels:
+  - conda-forge
+dependencies:
+  # conda environment builds
+  - conda-docker
+  - conda-pack
+  # web server
+  - sqlalchemy
+  - psycopg2
+  - requests
+  - flask
+  - flask-cors
+  - pyyaml
+  - pydantic
+  # artifact storage
+  - minio
+  # CLI
+  - typer
+
+  # dev dependencies
+  - pytest
+  - pytest-mock
+  - black ==21.5b0
+  - flake8
+  - sphinx
+  - recommonmark
+  - sphinx_rtd_theme

--- a/conda-store-server/setup.py
+++ b/conda-store-server/setup.py
@@ -44,7 +44,7 @@ setup(
         "dev": [
             "pytest",
             "pytest-mock",
-            "black==19.10b0",
+            "black==21.5b0",
             "flake8",
             "sphinx",
             "recommonmark",

--- a/shell.nix
+++ b/shell.nix
@@ -6,30 +6,5 @@ in
 pkgs.mkShell {
   buildInputs = [
     pkgs.docker-compose
-    pkgs.kubectl
-    pkgs.minikube
-    pkgs.vagrant
-    pkgs.ansible
-
-    pythonPackages.pyyaml
-    pythonPackages.flask
-    pythonPackages.flask-cors
-    pythonPackages.requests
-    pythonPackages.minio
-    pythonPackages.sqlalchemy
-    pythonPackages.minio
-    pythonPackages.pydantic
-
-    pythonPackages.pytest
-    pythonPackages.pytest-mock
-    pythonPackages.black
-    pythonPackages.flake8
-    pythonPackages.sphinx
-    pythonPackages.recommonmark
-    pythonPackages.sphinx_rtd_theme
   ];
-
-  shellHook = ''
-    export PATH="$PWD/node_modules/.bin/:$PATH"
-  '';
 }


### PR DESCRIPTION
This endpoint will serve several purposes:
 - easy integration with prometheus
 - provide an easy way to query the health of the cluster from ci