### PR TITLE
Adding conda env export

### DIFF
--- a/conda-store-server/conda_store_server/app.py
+++ b/conda-store-server/conda_store_server/app.py
@@ -244,6 +244,7 @@ class CondaStore(LoggingConfigurable):
         (
             tasks.task_update_storage_metrics.si()
             | tasks.task_build_conda_environment.si(build.id)
+            | tasks.task_build_conda_env_export.si(build.id)
             | tasks.task_build_conda_pack.si(build.id)
             | tasks.task_build_conda_docker.si(build.id)
             | tasks.task_update_storage_metrics.si()

--- a/conda-store-server/conda_store_server/build.py
+++ b/conda-store-server/conda_store_server/build.py
@@ -154,22 +154,20 @@ def build_conda_environment(conda_store, build):
 def build_conda_env_export(conda_store, build):
     conda_prefix = build.build_path(conda_store.store_directory)
 
-    output = subprocess.check_output([
-        conda_store.conda_command,
-        "env",
-        "export",
-        "-p",
-        conda_prefix
-    ])
+    output = subprocess.check_output(
+        [conda_store.conda_command, "env", "export", "-p", conda_prefix]
+    )
 
     parsed = yaml.safe_load(output)
     if "dependencies" not in parsed:
-        raise ValueError(f'conda env export` did not produce valid YAML:\n{output}')
+        raise ValueError(f"conda env export` did not produce valid YAML:\n{output}")
 
     conda_store.storage.set(
         conda_store.db,
         build.id,
-        build.conda_env_export_key, output, content_type="text/yaml"
+        build.conda_env_export_key,
+        output,
+        content_type="text/yaml",
     )
 
 

--- a/conda-store-server/conda_store_server/build.py
+++ b/conda-store-server/conda_store_server/build.py
@@ -151,6 +151,28 @@ def build_conda_environment(conda_store, build):
         set_build_failed(conda_store, build, traceback.format_exc().encode("utf-8"))
 
 
+def build_conda_env_export(conda_store, build):
+    conda_prefix = build.build_path(conda_store.store_directory)
+
+    output = subprocess.check_output([
+        conda_store.conda_command,
+        "env",
+        "export",
+        "-p",
+        conda_prefix
+    ])
+
+    parsed = yaml.safe_load(output)
+    if "dependencies" not in parsed:
+        raise ValueError(f'conda env export` did not produce valid YAML:\n{output}')
+
+    conda_store.storage.set(
+        conda_store.db,
+        build.id,
+        build.conda_env_export_key, output, content_type="text/yaml"
+    )
+
+
 def build_conda_pack(conda_store, build):
     conda_prefix = build.build_path(conda_store.store_directory)
 

--- a/conda-store-server/conda_store_server/orm.py
+++ b/conda-store-server/conda_store_server/orm.py
@@ -113,6 +113,10 @@ class Build(Base):
         return f"logs/{self.build_key}.log"
 
     @property
+    def conda_env_export_key(self):
+        return f"yaml/{self.build_key}.yml"
+
+    @property
     def conda_pack_key(self):
         return f"archive/{self.build_key}.tar.gz"
 

--- a/conda-store-server/conda_store_server/server/templates/build.html
+++ b/conda-store-server/conda_store_server/server/templates/build.html
@@ -65,6 +65,7 @@
         <h3 class="card-title">Conda Environment Artifacts</h3>
     </div>
     <ul class="list-group list-group-flush">
+        <li class="list-group-item">YAML: <a href="/build/{{ build.id }}/yaml/">environment.yaml</a></li>
         <li class="list-group-item">Lockfile: <a href="/build/{{ build.id }}/lockfile/">conda-{{ platform }}.lock</a></li>
         <li class="list-group-item">Archive: <a href="/build/{{ build.id }}/archive/">environment.tar.gz</a></li>
     </ul>

--- a/conda-store-server/conda_store_server/server/templates/home.html
+++ b/conda-store-server/conda_store_server/server/templates/home.html
@@ -11,7 +11,8 @@
             <a href="/environment/{{ environment.name }}/">{{ environment.namespace }}/{{ environment.name }}</a>
             <span class="badge badge-light">{{ (environment.build.size or 0) | filesizeformat(true) }}</span>
         </h5>
-        {% if environment.build_id is not none %}
+        {% if environment.build.status.value == 'COMPLETED' %}
+        <a class="card-link" href="/build/{{ environment.build_id }}/yaml/"><ion-icon name="code-download"></ion-icon> YAML</a>
         <a class="card-link" href="/build/{{ environment.build_id }}/lockfile/"><ion-icon name="lock-closed-outline"></ion-icon> Lockfile</a>
         <a class="card-link" href="/build/{{ environment.build_id }}/archive/"><ion-icon name="archive-outline"></ion-icon> Archive</a>
         <a class="card-link" onclick="setClipboard('localhost:5000/{{ environment.namespace }}/{{ environment.name }}:{{ environment.specification.sha256 }}')"><ion-icon name="logo-docker"></ion-icon> Docker</a>

--- a/conda-store-server/conda_store_server/server/views/ui.py
+++ b/conda-store-server/conda_store_server/server/views/ui.py
@@ -95,6 +95,13 @@ def api_get_build_lockfile(build_id):
     return Response(lockfile, mimetype="text/plain")
 
 
+@app_ui.route("/build/<build_id>/yaml/", methods=["GET"])
+def api_get_build_yaml(build_id):
+    conda_store = get_conda_store()
+    key = api.get_build(conda_store.db, build_id).conda_env_export_key
+    return redirect(conda_store.storage.get_url(key))
+
+
 @app_ui.route("/build/<build_id>/archive/", methods=["GET"])
 def api_get_build_archive(build_id):
     conda_store = get_conda_store()

--- a/conda-store-server/conda_store_server/worker/tasks.py
+++ b/conda-store-server/conda_store_server/worker/tasks.py
@@ -5,6 +5,7 @@ from conda_store_server.worker.utils import create_worker
 from conda_store_server import api, environment
 from conda_store_server.build import (
     build_conda_environment,
+    build_conda_env_export,
     build_conda_pack,
     build_conda_docker,
 )
@@ -45,6 +46,13 @@ def task_build_conda_environment(build_id):
     conda_store = create_worker().conda_store
     build = api.get_build(conda_store.db, build_id)
     build_conda_environment(conda_store, build)
+
+
+@task(name="task_build_conda_env_export")
+def task_build_conda_env_export(build_id):
+    conda_store = create_worker().conda_store
+    build = api.get_build(conda_store.db, build_id)
+    build_conda_env_export(conda_store, build)
 
 
 @task(name="task_build_conda_pack")


### PR DESCRIPTION
Closes #12. This for the most part copies #85 but adds support for the celery backend.