### PR TITLE
Enabling rollbacks of environment builds

### DIFF
--- a/conda-store-server/conda_store_server/api.py
+++ b/conda-store-server/conda_store_server/api.py
@@ -12,11 +12,14 @@ def list_environments(db, namespace: str = None, search=None):
     return db.query(orm.Environment).filter(*filters).all()
 
 
-def get_environment(db, name, namespace: str = None):
-    filters = [orm.Environment.name == name]
-
+def get_environment(db, name : str = None, namespace: str = None, id : int = None):
+    filters = []
+    if name:
+        filters.append(orm.Environment.name == name)
     if namespace:
         filters.append(orm.Environment.namespace == namespace)
+    if id:
+        filters.append(orm.Environment.id == id)
 
     return db.query(orm.Environment).filter(*filters).first()
 

--- a/conda-store-server/conda_store_server/api.py
+++ b/conda-store-server/conda_store_server/api.py
@@ -12,7 +12,7 @@ def list_environments(db, namespace: str = None, search=None):
     return db.query(orm.Environment).filter(*filters).all()
 
 
-def get_environment(db, name : str = None, namespace: str = None, id : int = None):
+def get_environment(db, name: str = None, namespace: str = None, id: int = None):
     filters = []
     if name:
         filters.append(orm.Environment.name == name)

--- a/conda-store-server/conda_store_server/app.py
+++ b/conda-store-server/conda_store_server/app.py
@@ -255,10 +255,14 @@ class CondaStore(LoggingConfigurable):
     def update_environment_build(self, name, build_id):
         build = api.get_build(self.db, build_id)
         if build.status != orm.BuildStatus.COMPLETED:
-            raise ValueError('cannot update environment to build id since not completed')
+            raise ValueError(
+                "cannot update environment to build id since not completed"
+            )
 
         if build.specification.name != name:
-            raise ValueError('cannot update environment to build id since specification does not match environment name')
+            raise ValueError(
+                "cannot update environment to build id since specification does not match environment name"
+            )
 
         environment = api.get_environment(self.db, name)
 

--- a/conda-store-server/conda_store_server/app.py
+++ b/conda-store-server/conda_store_server/app.py
@@ -251,3 +251,20 @@ class CondaStore(LoggingConfigurable):
         ).apply_async()
 
         return build
+
+    def update_environment_build(self, name, build_id):
+        build = api.get_build(self.db, build_id)
+        if build.status != orm.BuildStatus.COMPLETED:
+            raise ValueError('cannot update environment to build id since not completed')
+
+        if build.specification.name != name:
+            raise ValueError('cannot update environment to build id since specification does not match environment name')
+
+        environment = api.get_environment(self.db, name)
+
+        self.celery_app
+
+        # must import tasks after a celery app has been initialized
+        from conda_store_server.worker import tasks
+
+        tasks.task_update_environment_build.si(environment.id, build.id).apply_async()

--- a/conda-store-server/conda_store_server/server/templates/environment.html
+++ b/conda-store-server/conda_store_server/server/templates/environment.html
@@ -30,6 +30,11 @@
         <a href="/build/{{ build.id }}/">Build {{ build.id }}</a>
         <span>{{ build.status.value }}</span>
         <div class="btn-group" role="group" aria-label="Build actions">
+            {% if build.id != environment.build_id and build.status.value == 'COMPLETED' %}
+            <button type="button" onclick="updateEnvironmentBuild('{{ build.id }}')" class="btn btn-primary mb-2">
+                <ion-icon name="checkmark"></ion-icon>
+            </button>
+            {% endif %}
             <button type="button" onclick="buildAction('PUT', '{{ build.id }}')" class="btn btn-primary mb-2">
                 <ion-icon name="refresh"></ion-icon>
             </button>
@@ -42,6 +47,16 @@
 </ul>
 
 <script>
+  function updateEnvironmentBuild(buildId) {
+     fetch(`/api/v1/environment/{{ environment.name }}/`, {
+         method: 'PUT',
+         headers: {
+             'Content-Type': 'application/json',
+         },
+         body: JSON.stringify({"buildId": buildId})
+     })
+  }
+
  function buildAction(method, buildId) {
      fetch(`/api/v1/build/${buildId}/`, {
          method: method,

--- a/conda-store-server/conda_store_server/server/views/api.py
+++ b/conda-store-server/conda_store_server/server/views/api.py
@@ -32,6 +32,14 @@ def api_get_environment(name):
     return jsonify(environment)
 
 
+@app_api.route("/api/v1/environment/<name>/", methods=["PUT"])
+def api_update_environment_build(name):
+    conda_store = get_conda_store()
+    build_id = request.json['buildId']
+    conda_store.update_environment_build(name, build_id)
+    return jsonify({"status": "ok"})
+
+
 @app_api.route("/api/v1/specification/", methods=["GET"])
 def api_list_specification():
     conda_store = get_conda_store()

--- a/conda-store-server/conda_store_server/server/views/api.py
+++ b/conda-store-server/conda_store_server/server/views/api.py
@@ -35,7 +35,7 @@ def api_get_environment(name):
 @app_api.route("/api/v1/environment/<name>/", methods=["PUT"])
 def api_update_environment_build(name):
     conda_store = get_conda_store()
-    build_id = request.json['buildId']
+    build_id = request.json["buildId"]
     conda_store.update_environment_build(name, build_id)
     return jsonify({"status": "ok"})
 


### PR DESCRIPTION
Users can now select old builds for a given environment. Notice the checkmarks. I'm sure a better icon could be used.

![image](https://user-images.githubusercontent.com/1740337/126899899-08634ff3-22d8-47a8-840e-24659298c3b2.png)
