### PR TITLE
Adding scoped sqlalchemy sessions

### DIFF
--- a/conda-store-server/conda_store_server/app.py
+++ b/conda-store-server/conda_store_server/app.py
@@ -107,10 +107,10 @@ class CondaStore(LoggingConfigurable):
 
     @property
     def db(self):
-        if hasattr(self, "_db"):
-            return self._db
-        self._db = self.session_factory()
-        return self._db
+        # we are using a scoped_session which always returns the same
+        # session if within the same thread
+        # https://docs.sqlalchemy.org/en/14/orm/contextual.html
+        return self.session_factory()
 
     @property
     def configuration(self):

--- a/conda-store-server/conda_store_server/orm.py
+++ b/conda-store-server/conda_store_server/orm.py
@@ -15,7 +15,7 @@ from sqlalchemy import (
     UniqueConstraint,
     ForeignKey,
 )
-from sqlalchemy.orm import sessionmaker, relationship
+from sqlalchemy.orm import sessionmaker, relationship, scoped_session
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy import create_engine
 
@@ -296,5 +296,5 @@ def new_session_factory(url="sqlite:///:memory:", reset=False, **kwargs):
 
     Base.metadata.create_all(engine)
 
-    session_factory = sessionmaker(bind=engine)
+    session_factory = scoped_session(sessionmaker(bind=engine))
     return session_factory

--- a/conda-store-server/conda_store_server/server/app.py
+++ b/conda-store-server/conda_store_server/server/app.py
@@ -4,7 +4,6 @@ from flask import Flask
 from flask_cors import CORS
 from traitlets import Bool, Unicode, Integer, Type
 from traitlets.config import Application
-from sqlalchemy.orm.scoping import scoped_session
 
 from conda_store_server.server import views, auth
 from conda_store_server.app import CondaStore


### PR DESCRIPTION
Such a small PR but was the source of a lot of flask webpage / database state issues. The problem was that the session object in sqlalchemy was being reused between requests (not transactions) and this was causing the web api/ui to not reflect the true state of the database once the worker deleted/updated some environments.