### PR TITLE
Make conda-store environment build update command syncronous

### DIFF
--- a/conda-store-server/conda_store_server/app.py
+++ b/conda-store-server/conda_store_server/app.py
@@ -299,6 +299,7 @@ class CondaStore(LoggingConfigurable):
         self.celery_app
         # must import tasks after a celery app has been initialized
         from conda_store_server.worker import tasks
+
         tasks.task_update_environment_build.si(environment.id).apply_async()
 
     def delete_build(self, build_id):

--- a/conda-store-server/conda_store_server/server/templates/environment.html
+++ b/conda-store-server/conda_store_server/server/templates/environment.html
@@ -60,7 +60,7 @@
              'Content-Type': 'application/json',
          },
          body: JSON.stringify({"buildId": buildId})
-     })
+     }).then(response => window.location.reload(true));
  }
 
  function buildAction(method, buildId) {

--- a/conda-store-server/conda_store_server/utils.py
+++ b/conda-store-server/conda_store_server/utils.py
@@ -6,6 +6,18 @@ import time
 import hashlib
 import json
 
+from flask import jsonify
+
+
+class CondaStoreError(Exception):
+    @property
+    def message(self):
+        return self.args[0]
+
+    @property
+    def response(self):
+        return jsonify({"status": "error", "message": self.args[0]}), 400
+
 
 def symlink(source, target):
     if os.path.islink(target):

--- a/conda-store-server/conda_store_server/worker/tasks.py
+++ b/conda-store-server/conda_store_server/worker/tasks.py
@@ -78,7 +78,9 @@ def task_update_environment_build(environment_id):
     environment = api.get_environment(conda_store.db, id=environment_id)
 
     conda_prefix = environment.build.build_path(conda_store.store_directory)
-    environment_prefix = environment.build.environment_path(conda_store.environment_directory)
+    environment_prefix = environment.build.environment_path(
+        conda_store.environment_directory
+    )
 
     utils.symlink(conda_prefix, environment_prefix)
 

--- a/conda-store-server/conda_store_server/worker/tasks.py
+++ b/conda-store-server/conda_store_server/worker/tasks.py
@@ -73,19 +73,14 @@ def task_build_conda_docker(build_id):
 
 
 @task(name="task_update_environment_build")
-def task_update_environment_build(environment_id, build_id):
+def task_update_environment_build(environment_id):
     conda_store = create_worker().conda_store
-    build = api.get_build(conda_store.db, build_id)
+    environment = api.get_environment(conda_store.db, id=environment_id)
 
-    conda_prefix = build.build_path(conda_store.store_directory)
-    environment_prefix = build.environment_path(conda_store.environment_directory)
+    conda_prefix = environment.build.build_path(conda_store.store_directory)
+    environment_prefix = environment.build.environment_path(conda_store.environment_directory)
 
     utils.symlink(conda_prefix, environment_prefix)
-
-    environment = api.get_environment(conda_store.db, id=environment_id)
-    environment.build_id = build.id
-    environment.specification_id = build.specification.id
-    conda_store.db.commit()
 
 
 @task(name="task_delete_build")


### PR DESCRIPTION
Before this PR is a user decided to rollback an environment it would trigger a task (to be run at an unknown time in the future) that will update the database and then adjust the symlink pointing to the current environment. Now the database is updated with the request and the task now consults the database on what is the correct build to symlink to (making the task idempotent).