### PR TITLE
Adding syncronous delete method for environment builds

### DIFF
--- a/conda-store-server/conda_store_server/api.py
+++ b/conda-store-server/conda_store_server/api.py
@@ -1,3 +1,5 @@
+from typing import List
+
 from sqlalchemy import func
 
 from conda_store_server import orm
@@ -102,12 +104,22 @@ def get_build_lockfile(db, build_id):
     )
 
 
-def list_build_artifacts(db, limit: int = 25, build_id: int = None, key: str = None):
+def list_build_artifacts(
+    db,
+    limit: int = 25,
+    build_id: int = None,
+    key: str = None,
+    excluded_artifact_types: List[orm.BuildArtifactType] = None,
+):
     filters = []
     if build_id:
         filters.append(orm.BuildArtifact.build_id == build_id)
     if key:
         filters.append(orm.BuildArtifact.key == key)
+    if excluded_artifact_types:
+        filters.append(
+            func.not_(orm.BuildArtifact.artifact_type.in_(excluded_artifact_types))
+        )
 
     return db.query(orm.BuildArtifact).filter(*filters).limit(limit).all()
 

--- a/conda-store-server/conda_store_server/build.py
+++ b/conda-store-server/conda_store_server/build.py
@@ -21,7 +21,12 @@ def set_build_started(conda_store, build):
 
 def set_build_failed(conda_store, build, logs):
     conda_store.storage.set(
-        conda_store.db, build.id, build.log_key, logs, content_type="text/plain"
+        conda_store.db,
+        build.id,
+        build.log_key,
+        logs,
+        content_type="text/plain",
+        artifact_type=orm.BuildArtifactType.LOGS,
     )
     build.status = orm.BuildStatus.FAILED
     build.ended_on = datetime.datetime.utcnow()
@@ -72,7 +77,12 @@ def set_build_completed(conda_store, build, logs, packages):
             build.packages.append(_package)
 
     conda_store.storage.set(
-        conda_store.db, build.id, build.log_key, logs, content_type="text/plain"
+        conda_store.db,
+        build.id,
+        build.log_key,
+        logs,
+        content_type="text/plain",
+        artifact_type=orm.BuildArtifactType.LOGS,
     )
     build.status = orm.BuildStatus.COMPLETED
     build.ended_on = datetime.datetime.utcnow()
@@ -178,6 +188,7 @@ def build_conda_env_export(conda_store, build):
         build.conda_env_export_key,
         output,
         content_type="text/yaml",
+        artifact_type=orm.BuildArtifactType.YAML,
     )
 
 
@@ -194,6 +205,7 @@ def build_conda_pack(conda_store, build):
             build.conda_pack_key,
             output_filename,
             content_type="application/gzip",
+            artifact_type=orm.BuildArtifactType.CONDA_PACK,
         )
 
 
@@ -247,6 +259,7 @@ def build_conda_docker(conda_store, build):
             build.docker_blob_key(content_compressed_hash),
             content_compressed,
             content_type="application/gzip",
+            artifact_type=orm.BuildArtifactType.DOCKER,
         )
 
         docker_layer = schema.DockerManifestLayer(
@@ -273,6 +286,7 @@ def build_conda_docker(conda_store, build):
         build.docker_blob_key(docker_config_hash),
         docker_config_content,
         content_type="application/vnd.docker.container.image.v1+json",
+        artifact_type=orm.BuildArtifactType.DOCKER,
     )
 
     conda_store.storage.set(
@@ -281,6 +295,7 @@ def build_conda_docker(conda_store, build):
         build.docker_manifest_key,
         docker_manifest_content,
         content_type="application/vnd.docker.distribution.manifest.v2+json",
+        artifact_type=orm.BuildArtifactType.DOCKER,
     )
 
     # docker likes to have a sha256 key version of the manifest this
@@ -292,6 +307,7 @@ def build_conda_docker(conda_store, build):
         f"docker/manifest/{build.specification.name}/sha256:{docker_manifest_hash}",
         docker_manifest_content,
         content_type="application/vnd.docker.distribution.manifest.v2+json",
+        artifact_type=orm.BuildArtifactType.DOCKER,
     )
 
     conda_store.log.info(

--- a/conda-store-server/conda_store_server/orm.py
+++ b/conda-store-server/conda_store_server/orm.py
@@ -27,6 +27,13 @@ from conda_store_server.conda import download_repodata
 Base = declarative_base()
 
 
+class BuildArtifactType(enum.Enum):
+    LOGS = "LOGS"
+    YAML = "YAML"
+    CONDA_PACK = "CONDA_PACK"
+    DOCKER = "DOCKER"
+
+
 class BuildStatus(enum.Enum):
     QUEUED = "QUEUED"
     BUILDING = "BUILDING"
@@ -97,6 +104,7 @@ class Build(Base):
     scheduled_on = Column(DateTime, default=datetime.datetime.utcnow)
     started_on = Column(DateTime, default=None)
     ended_on = Column(DateTime, default=None)
+    deleted_on = Column(DateTime, default=None)
 
     def build_path(self, store_directory):
         store_path = os.path.abspath(store_directory)
@@ -149,6 +157,8 @@ class BuildArtifact(Base):
 
     build_id = Column(Integer, ForeignKey("build.id"))
     build = relationship(Build)
+
+    artifact_type = Column(Enum(BuildArtifactType), nullable=False)
 
     key = Column(String)
 

--- a/conda-store-server/conda_store_server/server/templates/environment.html
+++ b/conda-store-server/conda_store_server/server/templates/environment.html
@@ -25,11 +25,11 @@
 <h3>Builds</h3>
 <ul class="list-group">
     {% for build in environment_builds %}
-    <li class="list-group-item d-flex justify-content-between align-items-center {{ 'list-group-item-secondary' if build.id == environment.build_id else ''}}">
+    <li class="list-group-item d-flex justify-content-between align-items-center {% if build.id == environment.build_id %}list-group-item-success{% elif build.deleted_on is not none %}list-group-item-secondary{% endif %}">
         <a href="/build/{{ build.id }}/">Build {{ build.id }}</a>
         <span>{{ build.status.value }}</span>
         <div class="btn-group" role="group" aria-label="Build actions">
-            {% if build.id != environment.build_id and build.status.value == 'COMPLETED' %}
+            {% if build.id != environment.build_id and build.status.value == 'COMPLETED' and build.deleted_on is none %}
             <button type="button" onclick="updateEnvironmentBuild('{{ build.id }}')" class="btn btn-primary mb-2">
                 <ion-icon name="checkmark"></ion-icon>
             </button>
@@ -37,9 +37,11 @@
             <button type="button" onclick="buildAction('PUT', '{{ build.id }}')" class="btn btn-primary mb-2">
                 <ion-icon name="refresh"></ion-icon>
             </button>
+            {% if build.status.value in ["COMPLETED", "FAILED"] and  build.deleted_on is none %}
             <button type="button" onclick="buildAction('DELETE', '{{ build.id }}')" class="btn btn-primary mb-2">
                 <ion-icon name="trash"></ion-icon>
             </button>
+            {% endif %}
         </div>
     </li>
     {% endfor %}

--- a/conda-store-server/conda_store_server/worker/tasks.py
+++ b/conda-store-server/conda_store_server/worker/tasks.py
@@ -98,10 +98,14 @@ def task_delete_build(build_id):
     ):
         shutil.rmtree(conda_prefix)
 
+    conda_store.log.error("deleting artifacts")
     for build_artifact in api.list_build_artifacts(
-        conda_store.db, limit=None, build_id=build_id
+        conda_store.db,
+        limit=None,
+        build_id=build_id,
+        excluded_artifact_types=conda_store.build_artifacts_kept_on_deletion,
     ):
+        conda_store.log.error(f"deleting {build_artifact.key}")
         conda_store.storage.delete(conda_store.db, build_id, build_artifact.key)
 
-    conda_store.db.delete(build)
     conda_store.db.commit()


### PR DESCRIPTION
Currently the delete button trigger a task to delete the given build. The major problem with this is that when the user clicks delete the environment is not deleted immediately (this isn't possible so we have to mark the build for deletion). Then a task is kicked off to delete the given build. A conda_store configuration setting is available for users to choose which build artifacts are deleted.