### PR TITLE
Fix #129 : sort environments (and packages)

### DIFF
--- a/conda-store-server/conda_store_server/api.py
+++ b/conda-store-server/conda_store_server/api.py
@@ -20,7 +20,7 @@ def get_namespace(db, name: str = None, id: int = None):
     return db.query(orm.Namespace).filter(*filters).first()
 
 
-def list_environments(db, namespace: str = None, search: str = None):
+def list_environments(db, namespace: str = None, search: str = None, sort_by:str=None, order:str='asc'):
     filters = []
     if namespace:
         filters.append(orm.Namespace.name == namespace)
@@ -28,7 +28,19 @@ def list_environments(db, namespace: str = None, search: str = None):
     if search:
         filters.append(orm.Environment.name.contains(search, autoescape=True))
 
-    return db.query(orm.Environment).join(orm.Environment.namespace).filter(*filters)
+    result = db.query(orm.Environment).join(orm.Environment.namespace).filter(*filters)
+
+    if sort_by == 'name':
+        field = orm.Environment.name
+        order = field.desc() if order=='desc' else field.asc()
+        result = result.order_by(order)
+
+    elif sort_by == 'namespace':
+        field = orm.Environment.namespace
+        order = field.desc() if order=='desc' else field.asc()
+        result = result.order_by(order)
+    
+    return result
 
 
 def get_environment(

--- a/conda-store-server/conda_store_server/api.py
+++ b/conda-store-server/conda_store_server/api.py
@@ -146,7 +146,7 @@ def list_conda_packages(db, search: str = None):
     filters = []
     if search:
         filters.append(orm.CondaPackage.name.contains(search, autoescape=True))
-    return db.query(orm.CondaPackage).filter(*filters)
+    return db.query(orm.CondaPackage).join(orm.CondaChannel).filter(*filters)
 
 
 def get_metrics(db):

--- a/conda-store-server/conda_store_server/api.py
+++ b/conda-store-server/conda_store_server/api.py
@@ -24,8 +24,6 @@ def list_environments(
     db,
     namespace: str = None,
     search: str = None,
-    sort_by: str = None,
-    order: str = "asc",
 ):
     filters = []
     if namespace:
@@ -34,19 +32,7 @@ def list_environments(
     if search:
         filters.append(orm.Environment.name.contains(search, autoescape=True))
 
-    result = db.query(orm.Environment).join(orm.Environment.namespace).filter(*filters)
-
-    if sort_by == "name":
-        field = orm.Environment.name
-        order = field.desc() if order == "desc" else field.asc()
-        result = result.order_by(order)
-
-    elif sort_by == "namespace":
-        field = orm.Environment.namespace
-        order = field.desc() if order == "desc" else field.asc()
-        result = result.order_by(order)
-
-    return result
+    return db.query(orm.Environment).join(orm.Environment.namespace).filter(*filters)
 
 
 def get_environment(

--- a/conda-store-server/conda_store_server/api.py
+++ b/conda-store-server/conda_store_server/api.py
@@ -20,7 +20,13 @@ def get_namespace(db, name: str = None, id: int = None):
     return db.query(orm.Namespace).filter(*filters).first()
 
 
-def list_environments(db, namespace: str = None, search: str = None, sort_by:str=None, order:str='asc'):
+def list_environments(
+    db,
+    namespace: str = None,
+    search: str = None,
+    sort_by: str = None,
+    order: str = "asc",
+):
     filters = []
     if namespace:
         filters.append(orm.Namespace.name == namespace)
@@ -30,16 +36,16 @@ def list_environments(db, namespace: str = None, search: str = None, sort_by:str
 
     result = db.query(orm.Environment).join(orm.Environment.namespace).filter(*filters)
 
-    if sort_by == 'name':
+    if sort_by == "name":
         field = orm.Environment.name
-        order = field.desc() if order=='desc' else field.asc()
+        order = field.desc() if order == "desc" else field.asc()
         result = result.order_by(order)
 
-    elif sort_by == 'namespace':
+    elif sort_by == "namespace":
         field = orm.Environment.namespace
-        order = field.desc() if order=='desc' else field.asc()
+        order = field.desc() if order == "desc" else field.asc()
         result = result.order_by(order)
-    
+
     return result
 
 

--- a/conda-store-server/conda_store_server/server/views/api.py
+++ b/conda-store-server/conda_store_server/server/views/api.py
@@ -88,9 +88,12 @@ def api_list_environments():
 
     limit, offset = get_paginated_args(request)
 
-    sorts = {"namespace": orm.Environment.namespace, "name": orm.Environment.name}
+    allowed_sorts = {
+        "namespace": orm.Environment.namespace,
+        "name": orm.Environment.name,
+    }
 
-    sorts = get_sorts(request, allowed_sorts=sorts)
+    sorts = get_sorts(request, allowed_sorts)
 
     orm_environments = auth.filter_environments(
         api.list_environments(conda_store.db, search=search)

--- a/conda-store-server/conda_store_server/server/views/api.py
+++ b/conda-store-server/conda_store_server/server/views/api.py
@@ -26,8 +26,8 @@ def get_sorted_args(request, allowed_sorts=[]):
         sort_by = None
 
     order = request.args.get("order", "asc")
-    if order not in ['asc', 'desc']:
-        order = 'asc'
+    if order not in ["asc", "desc"]:
+        order = "asc"
 
     return sort_by, order
 
@@ -71,10 +71,12 @@ def api_list_environments():
 
     limit, offset = get_paginated_args(request)
 
-    sort_by, order = get_sorted_args(request, allowed_sorts=['namespace', 'name'])
-    
+    sort_by, order = get_sorted_args(request, allowed_sorts=["namespace", "name"])
+
     orm_environments = auth.filter_environments(
-        api.list_environments(conda_store.db, search=search, sort_by=sort_by, order=order)
+        api.list_environments(
+            conda_store.db, search=search, sort_by=sort_by, order=order
+        )
     )
     return paginated_api_response(
         orm_environments, schema.Environment, limit, offset, exclude={"current_build"}

--- a/conda-store-server/conda_store_server/server/views/api.py
+++ b/conda-store-server/conda_store_server/server/views/api.py
@@ -279,5 +279,15 @@ def api_list_packages():
     search = request.args.get("search")
 
     limit, offset = get_paginated_args(request)
+
+    allowed_sorts = {
+        "channel": orm.CondaChannel.name,
+        "name": orm.CondaPackage.name,
+    }
+
+    sorts = get_sorts(request, allowed_sorts)
+
     orm_packages = api.list_conda_packages(conda_store.db, search=search)
-    return paginated_api_response(orm_packages, schema.CondaPackage, limit, offset)
+    return paginated_api_response(
+        orm_packages, schema.CondaPackage, limit, offset, sorts
+    )

--- a/conda-store-server/conda_store_server/server/views/api.py
+++ b/conda-store-server/conda_store_server/server/views/api.py
@@ -20,6 +20,18 @@ def get_paginated_args(request):
     return size, offset
 
 
+def get_sorted_args(request, allowed_sorts=[]):
+    sort_by = request.args.get("sort_by", None)
+    if sort_by not in allowed_sorts:
+        sort_by = None
+
+    order = request.args.get("order", "asc")
+    if order not in ['asc', 'desc']:
+        order = 'asc'
+
+    return sort_by, order
+
+
 def paginated_api_response(query, object_schema, limit: int, offset: int, exclude=None):
     return jsonify(
         {
@@ -58,8 +70,11 @@ def api_list_environments():
     search = request.args.get("search")
 
     limit, offset = get_paginated_args(request)
+
+    sort_by, order = get_sorted_args(request, allowed_sorts=['namespace', 'name'])
+    
     orm_environments = auth.filter_environments(
-        api.list_environments(conda_store.db, search=search)
+        api.list_environments(conda_store.db, search=search, sort_by=sort_by, order=order)
     )
     return paginated_api_response(
         orm_environments, schema.Environment, limit, offset, exclude={"current_build"}

--- a/conda-store-server/conda_store_server/server/views/api.py
+++ b/conda-store-server/conda_store_server/server/views/api.py
@@ -42,11 +42,6 @@ def get_sorts(request, allowed_sorts: Dict = {}):
     return result
 
 
-# Todo :
-# - jsonify / paginate / sort+order
-#
-
-
 def paginated_api_response(
     query, object_schema, limit: int, offset: int, sorts: List = [], exclude=None
 ):

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -72,7 +72,12 @@ easier to contribute to the documentation.
 
 ### Environments
 
- - `GET /api/v1/environment/?search=<str>&page=<int>&size=<int>` :: list environments
+ - `GET /api/v1/environment/?search=<str>&page=<int>&size=<int>&sort_by=<str>&order=<str>` :: list environments
+   - allowed `sort_by` values : 
+     - `name` : sort by environment name
+     - `namespace` : sort by namespace's name
+   - `order` : `asc` or `desc`
+   
 
  - `GET /api/v1/environment/<namespace>/<name>/` :: get environment
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -25,7 +25,7 @@ are making and changes to conda-store-server and would like to see
 those changes in the deployment. Run.
 
 ```shell
-docker-compose down  # not always necissary
+docker-compose down  # not always necessary
 docker-compose up --build
 ```
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -73,10 +73,17 @@ easier to contribute to the documentation.
 ### Environments
 
  - `GET /api/v1/environment/?search=<str>&page=<int>&size=<int>&sort_by=<str>&order=<str>` :: list environments
-   - allowed `sort_by` values : 
-     - `name` : sort by environment name
-     - `namespace` : sort by namespace's name
-   - `order` : `asc` or `desc`
+   - allowed `sort_by` values : `namespace`, `name`
+   - allowed `order` values : `asc` or `desc`
+   - multiple `sort_by` parameters can be combined to sort by multiple fields.  
+```
+?sort_by=namespace                 -> sort by namespace
+?sort_by=name                      -> sort by name
+?sort_by=namespace&sort_by=name    -> sort by namespace and name
+?sort_by=name&sort_by=namespace    -> sort by name and namespace
+```
+   - Even if multiple `sort_by` parameters are given, only one `order` parameter is accepted. It will apply to each `sort_by`
+
    
 
  - `GET /api/v1/environment/<namespace>/<name>/` :: get environment

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -113,6 +113,19 @@ easier to contribute to the documentation.
 ### Conda Packages
 
  - `GET /api/v1/package/?search=<str>&page=<int>&size=<int>` :: list packages
+   - allowed `sort_by` values : `channel` to sort by channel name, `name` to sort by package name
+   - allowed `order` values : `asc` or `desc`
+   - multiple `sort_by` parameters can be combined to sort by multiple fields.  
+```
+?sort_by=channel                 -> sort by channel name
+?sort_by=name                    -> sort by package name
+?sort_by=channel&sort_by=name    -> sort by channel name and package name
+?sort_by=name&sort_by=channel    -> sort by package name and channel name
+```
+   - Even if multiple `sort_by` parameters are given, only one `order` parameter is accepted. It will apply to each `sort_by`
+
+
+
 
 ### REST API Query Format
 


### PR DESCRIPTION
This pull request aims at fixing issue #129 : sort environments returned by the API.

- Results from `api/v1/environment/` can now be sorted by env's namespace, or env's name, or both : 
```
?sort_by=namespace                 -> sort by namespace
?sort_by=name                      -> sort by name
?sort_by=namespace&sort_by=name    -> sort by namespace and name
?sort_by=name&sort_by=namespace    -> sort by name and namespace
```

- Also, this PR contains commits to sort results from `api/v1/package/` as well : 
```
?sort_by=channel                 -> sort by channel name
?sort_by=name                    -> sort by package name
?sort_by=channel&sort_by=name    -> sort by channel name and package name
?sort_by=name&sort_by=channel    -> sort by package name and channel name
```
Regarding this point, @costrouc I'll ask for a specific review of [this commit ](https://github.com/Quansight/conda-store/commit/d43cab6d5470e6524424d1d111614365b86c9e0c#). In the core api, in function `list_conda_packages`, I had to add a join on `orm.CondaChannel` to be able to sort packages by channel's name. Let me know if you see any impact I might have missed here.



