### PR TITLE
Fix 191 to only show non-deleted environments/namespaces

### DIFF
--- a/conda-store-server/conda_store_server/api.py
+++ b/conda-store-server/conda_store_server/api.py
@@ -9,7 +9,7 @@ from .conda import conda_platform
 def list_namespaces(db, show_soft_deleted : bool = False):
     filters = []
     if not show_soft_deleted:
-        filters.append(orm.Namespace.deleted_on is None)
+        filters.append(orm.Namespace.deleted_on == None)
 
     return db.query(orm.Namespace).filter(*filters)
 
@@ -48,7 +48,7 @@ def list_environments(
         filters.append(orm.Environment.name.contains(search, autoescape=True))
 
     if not show_soft_deleted:
-        filters.append(orm.Environment.deleted_on is None)
+        filters.append(orm.Environment.deleted_on == None)
 
     return db.query(orm.Environment).join(orm.Environment.namespace).filter(*filters)
 
@@ -94,7 +94,7 @@ def list_builds(db, status: orm.BuildStatus = None, show_soft_deleted: bool= Fal
         filters.append(orm.Build.status == status)
 
     if not show_soft_deleted:
-        filters.append(orm.Build.deleted_on is None)
+        filters.append(orm.Build.deleted_on == None)
 
     return db.query(orm.Build).filter(*filters)
 

--- a/conda-store-server/conda_store_server/api.py
+++ b/conda-store-server/conda_store_server/api.py
@@ -1,15 +1,15 @@
 from typing import List
 
-from sqlalchemy import func
+from sqlalchemy import func, null
 
 from conda_store_server import orm
 from .conda import conda_platform
 
 
-def list_namespaces(db, show_soft_deleted : bool = False):
+def list_namespaces(db, show_soft_deleted: bool = False):
     filters = []
     if not show_soft_deleted:
-        filters.append(orm.Namespace.deleted_on == None)
+        filters.append(orm.Namespace.deleted_on == null())
 
     return db.query(orm.Namespace).filter(*filters)
 
@@ -48,7 +48,7 @@ def list_environments(
         filters.append(orm.Environment.name.contains(search, autoescape=True))
 
     if not show_soft_deleted:
-        filters.append(orm.Environment.deleted_on == None)
+        filters.append(orm.Environment.deleted_on == null())
 
     return db.query(orm.Environment).join(orm.Environment.namespace).filter(*filters)
 
@@ -88,13 +88,13 @@ def post_specification(conda_store, specification, namespace=None):
     conda_store.register_environment(specification, namespace)
 
 
-def list_builds(db, status: orm.BuildStatus = None, show_soft_deleted: bool= False):
+def list_builds(db, status: orm.BuildStatus = None, show_soft_deleted: bool = False):
     filters = []
     if status:
         filters.append(orm.Build.status == status)
 
     if not show_soft_deleted:
-        filters.append(orm.Build.deleted_on == None)
+        filters.append(orm.Build.deleted_on == null())
 
     return db.query(orm.Build).filter(*filters)
 

--- a/conda-store-server/conda_store_server/api.py
+++ b/conda-store-server/conda_store_server/api.py
@@ -6,8 +6,11 @@ from conda_store_server import orm
 from .conda import conda_platform
 
 
-def list_namespaces(db):
+def list_namespaces(db, show_soft_deleted : bool = False):
     filters = []
+    if not show_soft_deleted:
+        filters.append(orm.Namespace.deleted_on is None)
+
     return db.query(orm.Namespace).filter(*filters)
 
 
@@ -35,6 +38,7 @@ def list_environments(
     db,
     namespace: str = None,
     search: str = None,
+    show_soft_deleted: bool = False,
 ):
     filters = []
     if namespace:
@@ -42,6 +46,9 @@ def list_environments(
 
     if search:
         filters.append(orm.Environment.name.contains(search, autoescape=True))
+
+    if not show_soft_deleted:
+        filters.append(orm.Environment.deleted_on is None)
 
     return db.query(orm.Environment).join(orm.Environment.namespace).filter(*filters)
 
@@ -81,10 +88,13 @@ def post_specification(conda_store, specification, namespace=None):
     conda_store.register_environment(specification, namespace)
 
 
-def list_builds(db, status: orm.BuildStatus = None):
+def list_builds(db, status: orm.BuildStatus = None, show_soft_deleted: bool= False):
     filters = []
     if status:
         filters.append(orm.Build.status == status)
+
+    if not show_soft_deleted:
+        filters.append(orm.Build.deleted_on is None)
 
     return db.query(orm.Build).filter(*filters)
 

--- a/conda-store-server/conda_store_server/server/views/api.py
+++ b/conda-store-server/conda_store_server/server/views/api.py
@@ -106,7 +106,8 @@ def api_list_namespaces():
     conda_store = get_conda_store()
     auth = get_auth()
 
-    orm_namespaces = auth.filter_namespaces(api.list_namespaces(conda_store.db))
+    orm_namespaces = auth.filter_namespaces(
+        api.list_namespaces(conda_store.db, show_soft_deleted=False))
     return paginated_api_response(
         orm_namespaces,
         schema.Namespace,
@@ -176,7 +177,7 @@ def api_list_environments():
     search = request.args.get("search")
 
     orm_environments = auth.filter_environments(
-        api.list_environments(conda_store.db, search=search)
+        api.list_environments(conda_store.db, search=search, show_soft_deleted=False)
     )
     return paginated_api_response(
         orm_environments,
@@ -284,7 +285,7 @@ def api_list_builds():
     conda_store = get_conda_store()
     auth = get_auth()
 
-    orm_builds = auth.filter_builds(api.list_builds(conda_store.db))
+    orm_builds = auth.filter_builds(api.list_builds(conda_store.db, show_soft_deleted=True))
     return paginated_api_response(
         orm_builds,
         schema.Build,

--- a/conda-store-server/conda_store_server/server/views/api.py
+++ b/conda-store-server/conda_store_server/server/views/api.py
@@ -107,7 +107,8 @@ def api_list_namespaces():
     auth = get_auth()
 
     orm_namespaces = auth.filter_namespaces(
-        api.list_namespaces(conda_store.db, show_soft_deleted=False))
+        api.list_namespaces(conda_store.db, show_soft_deleted=False)
+    )
     return paginated_api_response(
         orm_namespaces,
         schema.Namespace,
@@ -285,7 +286,9 @@ def api_list_builds():
     conda_store = get_conda_store()
     auth = get_auth()
 
-    orm_builds = auth.filter_builds(api.list_builds(conda_store.db, show_soft_deleted=True))
+    orm_builds = auth.filter_builds(
+        api.list_builds(conda_store.db, show_soft_deleted=True)
+    )
     return paginated_api_response(
         orm_builds,
         schema.Build,

--- a/conda-store-server/conda_store_server/server/views/ui.py
+++ b/conda-store-server/conda_store_server/server/views/ui.py
@@ -22,7 +22,7 @@ def ui_create_get_environment():
     conda_store = get_conda_store()
     auth = get_auth()
 
-    orm_namespaces = auth.filter_namespaces(api.list_namespaces(conda_store.db))
+    orm_namespaces = auth.filter_namespaces(api.list_namespaces(conda_store.db, show_soft_deleted=False))
 
     context = {
         "namespaces": orm_namespaces.all(),
@@ -63,7 +63,7 @@ def ui_list_environments():
     server = get_server()
     auth = get_auth()
 
-    orm_environments = auth.filter_environments(api.list_environments(conda_store.db))
+    orm_environments = auth.filter_environments(api.list_environments(conda_store.db, show_soft_deleted=False))
 
     context = {
         "environments": orm_environments.all(),
@@ -79,7 +79,7 @@ def ui_list_namespaces():
     conda_store = get_conda_store()
     auth = get_auth()
 
-    orm_namespaces = auth.filter_namespaces(api.list_namespaces(conda_store.db))
+    orm_namespaces = auth.filter_namespaces(api.list_namespaces(conda_store.db, show_soft_deleted=False))
 
     context = {
         "namespaces": orm_namespaces.all(),

--- a/conda-store-server/conda_store_server/server/views/ui.py
+++ b/conda-store-server/conda_store_server/server/views/ui.py
@@ -22,7 +22,9 @@ def ui_create_get_environment():
     conda_store = get_conda_store()
     auth = get_auth()
 
-    orm_namespaces = auth.filter_namespaces(api.list_namespaces(conda_store.db, show_soft_deleted=False))
+    orm_namespaces = auth.filter_namespaces(
+        api.list_namespaces(conda_store.db, show_soft_deleted=False)
+    )
 
     context = {
         "namespaces": orm_namespaces.all(),
@@ -63,7 +65,9 @@ def ui_list_environments():
     server = get_server()
     auth = get_auth()
 
-    orm_environments = auth.filter_environments(api.list_environments(conda_store.db, show_soft_deleted=False))
+    orm_environments = auth.filter_environments(
+        api.list_environments(conda_store.db, show_soft_deleted=False)
+    )
 
     context = {
         "environments": orm_environments.all(),
@@ -79,7 +83,9 @@ def ui_list_namespaces():
     conda_store = get_conda_store()
     auth = get_auth()
 
-    orm_namespaces = auth.filter_namespaces(api.list_namespaces(conda_store.db, show_soft_deleted=False))
+    orm_namespaces = auth.filter_namespaces(
+        api.list_namespaces(conda_store.db, show_soft_deleted=False)
+    )
 
     context = {
         "namespaces": orm_namespaces.all(),


### PR DESCRIPTION
In the `conda_store_server.api` methods for list_environment, list_builds, and list_namespaces there is now a `show_soft_deleted` option which is by default False.

We set show_soft_deleted to True for builds since often we would like to see builds that have been deleted but several artifacsts are still kept. 

Closes #191 