### PR TITLE
Fix #198 : psycopg2-binary

### DIFF
--- a/conda-store-server/environment-dev.yaml
+++ b/conda-store-server/environment-dev.yaml
@@ -10,7 +10,7 @@ dependencies:
   - flower
   - redis-py
   - sqlalchemy
-  - psycopg2
+  - psycopg2-binary
   - requests
   - flask
   - flask-cors

--- a/conda-store-server/environment.yaml
+++ b/conda-store-server/environment.yaml
@@ -10,7 +10,7 @@ dependencies:
   - flower
   - redis-py
   - sqlalchemy
-  - psycopg2
+  - psycopg2-binary
   - requests
   - flask
   - flask-cors

--- a/conda-store-server/setup.py
+++ b/conda-store-server/setup.py
@@ -33,7 +33,7 @@ setup(
         "conda-pack",
         "celery",
         "sqlalchemy",
-        "psycopg2",
+        "psycopg2-binary",
         "requests",
         "flask",
         "flask-cors",


### PR DESCRIPTION
Replace `psycopg2` with `psycopg2-binary`.

References :
Issue open by @yuvipanda : https://github.com/Quansight/conda-store/issues/198
The reason behind using the `-binary` version : https://www.psycopg.org/articles/2018/02/08/psycopg-274-released/
