### PR TITLE
Pin nodejs to v16 in conda-store/environment.yaml

### DIFF
--- a/conda-store/environment.yaml
+++ b/conda-store/environment.yaml
@@ -6,6 +6,7 @@ dependencies:
   - jupyterhub
   - jupyterlab>=3.0.0
   - nb_conda_kernels
+  - nodejs=16
   - yarn
   - pip:
     - https://github.com/yuvipanda/jupyter-launcher-shortcuts/archive/refs/heads/master.zip


### PR DESCRIPTION
Yesterday the following command from https://github.com/Quansight/gator/tree/conda-store-integration failed for me:

```sh
cd conda-store/examples/docker/
docker compose up --build
```

I traced back the errors until I was able to reproduce the same error locally when trying to pip install [Quansight/gator[branch=list-installed-conda-store-packages]](https://github.com/Quansight/gator/tree/list-installed-conda-store-packages)

As you can see in [my terminal log](https://gist.github.com/gabalafou/0ca8e806afa7996ee2fd466441a09a09), trying to pip install that repo branch when `node --version` = 17 fails, whereas it succeeds when `node --version` = 16.