### PR TITLE
[WIP] Add endpoint to list all versions of an available package

### DIFF
--- a/conda-store-server/conda_store_server/server/views/api.py
+++ b/conda-store-server/conda_store_server/server/views/api.py
@@ -452,6 +452,23 @@ def api_list_packages():
         required_sort_bys=required_sort_bys,
     )
 
+@app_api.route("/api/v1/packageversions/", methods=["GET"])
+def api_list_package_versions():
+    conda_store = get_conda_store()
+
+    search = request.args.get("search")
+    build = request.args.get("build")
+
+    orm_packages = api.list_conda_package_versions(conda_store.db, search=search, build=build)
+    packages = []
+    for name, versions in orm_packages.all():
+        packages.append(
+            {
+                "name": name,
+                "versions": versions.split(',')
+            }
+        )
+    return {"packages": packages}
 
 @app_api.route("/api/v1/build/<build_id>/yaml/", methods=["GET"])
 def api_get_build_yaml(build_id):


### PR DESCRIPTION
## Summary
This PR adds an endpoint which lists all the versions of an available package. See #221 for motivation.

This PR is still a work in progress, but I wanted to open it early to encourage discussion about the approach. There's still a bit of work to be done:

- [ ] Feedback: is this an appropriate feature to add?
- [ ] Feedback: Is the endpoint is appropriately named? Currently it is `/api/v1/packageversions/` but this could easily be changed
- [ ] Documentation for the endpoint
- [ ] Add schema for the response, call `<schema>.from_orm()` on each entry to validate
- [ ] Paginate the response

## Changes
* Added an endpoint `/api/v1/packageversions/` which lists all the unique versions of available packages.

Here's what the response looks like in my naive approach:

```json
{
  "packages": [
    {
      "name": "21cmfast", 
      "versions": [
        "3.0.2", 
        "3.0.3", 
        "3.1.1", 
        "3.1.2", 
        "3.1.3"
      ]
    }, 
    {
      "name": "2dfatmic", 
      "versions": [
        "1.0"
      ]
    }, 
    {
      "name": "4ti2", 
      "versions": [
        "1.6.9"
      ]
    }, 
    {
      "name": "aadict", 
      "versions": [
        "0.2.3"
      ]
    }, 
    {
      "name": "aalto-boss", 
      "versions": [
        "1.1", 
        "1.2", 
        "1.3", 
        "1.4", 
        "1.5"
      ]
    }, 
    {
      "name": "abc-classroom", 
      "versions": [
        "0.0.15", 
        "0.1.0", 
        "0.1.4", 
        "0.1.5", 
        "0.1.6", 
        "0.1.7", 
        "0.1.8", 
        "0.1.9"
      ]
    }, 
    ...
}
```