### PR TITLE
Accepting paths with and without a trailing slash

### DIFF
--- a/conda-store-server/conda_store_server/server/app.py
+++ b/conda-store-server/conda_store_server/server/app.py
@@ -95,6 +95,10 @@ class CondaStoreServer(Application):
 
     def start(self):
         app = Flask(__name__)
+
+        # ensure that urls are valid with and without a trailing slash
+        app.url_map.strict_slashes = False
+
         cors_prefix = f"{self.url_prefix if self.url_prefix != '/' else ''}"
         CORS(
             app,


### PR DESCRIPTION
Closes #217

This is a painful issue when dealing with https. In https the redirect
was causing CORS issues when redirecting the user from /api/v1 ->
/api/v1/ for example. This will no longer be an issue with this fix.