### PR TITLE
Adding an validation for namespace and name via regex

### DIFF
--- a/conda-store-server/conda_store_server/api.py
+++ b/conda-store-server/conda_store_server/api.py
@@ -1,9 +1,10 @@
 from typing import List
+import re
 
 from sqlalchemy import func, null
 
-from conda_store_server import orm
-from .conda import conda_platform
+from conda_store_server import orm, schema
+from conda_store_server.conda import conda_platform
 
 
 def list_namespaces(db, show_soft_deleted: bool = False):
@@ -24,8 +25,14 @@ def get_namespace(db, name: str = None, id: int = None):
 
 
 def create_namespace(db, name: str):
+    if re.fullmatch(f"[{schema.ALLOWED_CHARACTERS}]+", name) is None:
+        raise ValueError(
+            f"Namespace='{name}' is not valid does not match regex {schema.NAMESPACE_REGEX}"
+        )
+
     namespace = orm.Namespace(name=name)
     db.add(namespace)
+    return namespace
 
 
 def delete_namespace(db, name: str = None, id: int = None):

--- a/conda-store-server/conda_store_server/app.py
+++ b/conda-store-server/conda_store_server/app.py
@@ -202,7 +202,7 @@ class CondaStore(LoggingConfigurable):
         """Ensure that conda-store default namespaces exists"""
         namespace = api.get_namespace(self.db, name=self.default_namespace)
         if namespace is None:
-            self.db.add(orm.Namespace(name=self.default_namespace))
+            api.create_namespace(self.db, name=self.default_namespace)
 
     def ensure_directories(self):
         """Ensure that conda-store filesystem directories exist"""
@@ -239,8 +239,7 @@ class CondaStore(LoggingConfigurable):
         # Create Namespace if namespace if it does not exist
         namespace_model = api.get_namespace(self.db, name=namespace)
         if namespace_model is None:
-            namespace = orm.Namespace(name=namespace)
-            self.db.add(namespace)
+            namespace = api.create_namespace(self.db, name=namespace)
             self.db.commit()
         else:
             namespace = namespace_model

--- a/conda-store-server/conda_store_server/conda.py
+++ b/conda-store-server/conda_store_server/conda.py
@@ -2,8 +2,8 @@ import json
 import subprocess
 import bz2
 import datetime
-import yarl
 
+import yarl
 import requests
 
 

--- a/conda-store-server/conda_store_server/schema.py
+++ b/conda-store-server/conda_store_server/schema.py
@@ -3,7 +3,7 @@ import enum
 from typing import List, Optional, Union, Dict
 import functools
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, constr
 
 
 def _datetime_factory(offset: datetime.timedelta):
@@ -57,9 +57,14 @@ class CondaPackage(BaseModel):
         orm_mode = True
 
 
+# namespace and name cannot contain "*" ":" "#" " " "/"
+# this is a more restrictive list
+ALLOWED_CHARACTERS = "A-Za-z0-9-+_=@$&?^|~."
+
+
 class Namespace(BaseModel):
     id: int
-    name: str
+    name: constr(regex=f"^[{ALLOWED_CHARACTERS}]+$")  # noqa: F722
 
     class Config:
         orm_mode = True
@@ -109,8 +114,7 @@ class CondaSpecificationPip(BaseModel):
 
 
 class CondaSpecification(BaseModel):
-    # not allowed charaters in conda environment name '/', ' ', ':'
-    name: str
+    name: constr(regex=f"^[{ALLOWED_CHARACTERS}]+$")  # noqa: F722
     channels: Optional[List[str]]
     dependencies: List[Union[str, CondaSpecificationPip]]
     prefix: Optional[str]

--- a/conda-store-server/conda_store_server/server/auth.py
+++ b/conda-store-server/conda_store_server/server/auth.py
@@ -23,7 +23,7 @@ from conda_store_server import schema, orm
 
 
 ARN_ALLOWED_REGEX = re.compile(
-    r"^([A-Za-z0-9|<>=\.\_\-\*]+)/([A-Za-z0-9|<>=\.\_\-\*]+)$"
+    f"^([{schema.ALLOWED_CHARACTERS}*]+)/([{schema.ALLOWED_CHARACTERS}*]+)$"
 )
 
 
@@ -123,9 +123,8 @@ class RBACAuthorizationBackend(LoggingConfigurable):
         if not ARN_ALLOWED_REGEX.match(arn):
             raise ValueError(f"invalid arn={arn}")
 
-        # replace "*" with "[A-Za-z0-9_\-\.|<>=]*"
-        arn = re.sub(r"\*", r"[A-Za-z0-9_\-\.|<>=]*", arn)
-
+        # replace "*" with schema.ALLOWED_CHARACTERS
+        arn = re.sub(r"\*", f"[{schema.ALLOWED_CHARACTERS}]*", arn)
         namespace_regex, name_regex = arn.split("/")
         regex_arn = "^" + namespace_regex + "(?:/" + name_regex + ")?$"
         return re.compile(regex_arn)

--- a/conda-store-server/conda_store_server/server/views/api.py
+++ b/conda-store-server/conda_store_server/server/views/api.py
@@ -149,9 +149,11 @@ def api_create_namespace(namespace):
     if namespace_orm:
         return jsonify({"status": "error", "error": "namespace already exists"}), 409
 
-    api.create_namespace(conda_store.db, namespace)
+    try:
+        api.create_namespace(conda_store.db, namespace)
+    except ValueError as e:
+        return jsonify({"status": "error", "message": str(e.args[0])}), 400
     conda_store.db.commit()
-
     return jsonify({"status": "ok"})
 
 
@@ -277,7 +279,11 @@ def api_post_specification():
         require=True,
     )
 
-    api.post_specification(conda_store, specification, namespace_name)
+    try:
+        api.post_specification(conda_store, specification, namespace_name)
+    except ValueError as e:
+        return jsonify({"status": "error", "error": str(e.args[0])}), 400
+
     return jsonify({"status": "ok"})
 
 


### PR DESCRIPTION
Closes #227 

This PR adds further validation on the name and namespace used in Conda-Store. Additionally allows for namespaces and names to support email like namespaces/names. 