### PR TITLE
Adding ability for conda-store server to use proxy X-Forward- headers

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -2,8 +2,6 @@ name: Documentation
 
 on:
   pull_request:
-    branches:
-      - main
     paths:
       - '**.md'
   push:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -2,8 +2,6 @@ name: Tests
 
 on:
   pull_request:
-    branches:
-      - main
   push:
     branches:
       - main

--- a/conda-store-server/conda_store_server/server/app.py
+++ b/conda-store-server/conda_store_server/server/app.py
@@ -70,7 +70,7 @@ class CondaStoreServer(Application):
     behind_proxy = Bool(
         False,
         help="Indicates if server is behind web reverse proxy such as nginx, traefik, apache. Will use X-Forward-.. headers to detemine scheme. Do not set to true if not behind proxy since Flask will trust any X-Forward-... header",
-        config=True
+        config=True,
     )
 
     @validate("config_file")

--- a/conda-store-server/conda_store_server/server/app.py
+++ b/conda-store-server/conda_store_server/server/app.py
@@ -5,6 +5,7 @@ import sys
 from flask import Flask
 from flask.blueprints import Blueprint
 from flask_cors import CORS
+from werkzeug.middleware.proxy_fix import ProxyFix
 from traitlets import Bool, Unicode, Integer, Type, validate
 from traitlets.config import Application
 
@@ -66,6 +67,12 @@ class CondaStoreServer(Application):
         config=True,
     )
 
+    behind_proxy = Bool(
+        False,
+        help="Indicates if server is behind web reverse proxy such as nginx, traefik, apache. Will use X-Forward-.. headers to detemine scheme. Do not set to true if not behind proxy since Flask will trust any X-Forward-... header",
+        config=True
+    )
+
     @validate("config_file")
     def _validate_config_file(self, proposal):
         if not os.path.isfile(proposal.value):
@@ -95,6 +102,9 @@ class CondaStoreServer(Application):
 
     def start(self):
         app = Flask(__name__)
+
+        if self.behind_proxy:
+            app.wsgi_app = ProxyFix(app.wsgi_app)
 
         # ensure that urls are valid with and without a trailing slash
         app.url_map.strict_slashes = False

--- a/conda-store-server/conda_store_server/server/app.py
+++ b/conda-store-server/conda_store_server/server/app.py
@@ -69,7 +69,7 @@ class CondaStoreServer(Application):
 
     behind_proxy = Bool(
         False,
-        help="Indicates if server is behind web reverse proxy such as nginx, traefik, apache. Will use X-Forward-.. headers to detemine scheme. Do not set to true if not behind proxy since Flask will trust any X-Forward-... header",
+        help="Indicates if server is behind web reverse proxy such as Nginx, Traefik, Apache. Will use X-Forward-.. headers to detemine scheme. Do not set to true if not behind proxy since Flask will trust any X-Forward-... header",
         config=True,
     )
 

--- a/docs/administration.md
+++ b/docs/administration.md
@@ -378,8 +378,8 @@ point since also used in `AuthenticationBackend`.
 in a single UI page or API response.
 
 `CondaStoreServer.behind_proxy` indicates if server is behind web
-reverse proxy such as nginx, traefik, apache. Will use
-X-Forward-.. headers to determine scheme. Do not set to true if not
+reverse proxy such as Nginx, Traefik, Apache. Will use
+`X-Forward-...` headers to determine scheme. Do not set to true if not
 behind proxy since Flask will trust any `X-Forward-...` header.
 
 ### `conda_store_server.worker.app.CondaStoreWorker`

--- a/docs/administration.md
+++ b/docs/administration.md
@@ -377,6 +377,11 @@ point since also used in `AuthenticationBackend`.
 `CondaStoreServer.max_page_size` is maximum number of items to return
 in a single UI page or API response.
 
+`CondaStoreServer.behind_proxy` indicates if server is behind web
+reverse proxy such as nginx, traefik, apache. Will use
+X-Forward-.. headers to determine scheme. Do not set to true if not
+behind proxy since Flask will trust any `X-Forward-...` header.
+
 ### `conda_store_server.worker.app.CondaStoreWorker`
 
 `CondaStoreWorker.log_level` is the level for all server

--- a/tests/vale/styles/vocab.txt
+++ b/tests/vale/styles/vocab.txt
@@ -46,3 +46,5 @@ pytest
 lorri
 nixery
 PyPi
+Traefik
+Nginx


### PR DESCRIPTION
This uses Flask ProxyFix https://werkzeug.palletsprojects.com/en/2.0.x/middleware/proxy_fix/ with setting `c.CondaStoreServer.behind_proxy = True|False`

This will address the issue seen in quansight/qhub#1121