### PR TITLE
Limits to the concurrency of celery/conda-store-worker

### DIFF
--- a/conda-store-server/conda_store_server/worker/app.py
+++ b/conda-store-server/conda_store_server/worker/app.py
@@ -23,6 +23,12 @@ class CondaStoreWorker(Application):
         [], help="list of paths to watch for environment changes", config=True
     )
 
+    concurrency = Integer(
+        None,
+        help="Number of worker threads to spawn. Limit the concurrency of conda-builds",
+        config=True,
+    )
+
     config_file = Unicode(
         help="config file to load for conda-store",
         config=True,
@@ -58,5 +64,9 @@ class CondaStoreWorker(Application):
             "--loglevel=INFO",
             "--beat",
         ]
+
+        if self.concurrency:
+            argv.append(f"--concurrency={self.concurrency}")
+
         self.conda_store.ensure_directories()
         self.conda_store.celery_app.worker_main(argv)

--- a/docs/administration.md
+++ b/docs/administration.md
@@ -392,6 +392,10 @@ logging. Default is `INFO`. Common options are `DEBUG`, `INFO`,
 watch for changes to directories of `environment.yaml` files or a
 single filename to watch.
 
+`CondaStoreWorker.concurrency` by default is not set and defaults to
+the number of threads on your given machine. If set will limit the
+number of concurrent celery tasks to the integer.
+
 ## Frequently Asked Questions
 
 ### Conda-Store fails to build Conda environment and worker is spontaneously killed (9 SIGKILL)

--- a/tests/assets/conda_store_config.py
+++ b/tests/assets/conda_store_config.py
@@ -57,3 +57,4 @@ c.JupyterHubOAuthAuthentication.authorize_url = "http://localhost:8000/hub/api/o
 # ==================================
 c.CondaStoreWorker.log_level = logging.INFO
 c.CondaStoreWorker.watch_paths = ["/opt/environments"]
+c.CondaStoreWorker.concurrency = 4


### PR DESCRIPTION
Closes #247

This is a shorter term fix but does seem to effectively limit the
number of connections.