### PR TITLE
Add concurrency setting to example Docker Conda Store config file

### DIFF
--- a/examples/docker/assets/conda_store_config.py
+++ b/examples/docker/assets/conda_store_config.py
@@ -55,3 +55,4 @@ c.JupyterHubOAuthAuthentication.authorize_url = "http://localhost:8000/hub/api/o
 # ==================================
 c.CondaStoreWorker.log_level = logging.INFO
 c.CondaStoreWorker.watch_paths = ["/opt/conda-store/environments/"]
+c.CondaStoreWorker.concurrency = 4


### PR DESCRIPTION
I think this got overlooked in #250