### PR TITLE
Specification custom validation and modifications

### DIFF
--- a/conda-store-server/Dockerfile
+++ b/conda-store-server/Dockerfile
@@ -7,6 +7,10 @@ RUN apt-get update \
     && apt-get install -y wait-for-it \
     && rm -rf /var/lib/apt/lists/*
 
+# ensure that conda channels is empty by default
+# we do not want to tamper with the solve
+RUN printf 'channels: []\n' > /opt/conda/.condarc
+
 COPY environment.yaml /opt/conda-store-server/environment.yaml
 
 RUN mamba env create -f /opt/conda-store-server/environment.yaml

--- a/conda-store-server/conda_store_server/conda.py
+++ b/conda-store-server/conda_store_server/conda.py
@@ -45,7 +45,9 @@ def download_repodata(
     # the https://conda.anaconda.org/<channel>/channeldata.json
     # so we replace the given url with it's equivalent alias
     channel_replacements = {
-        yarl.URL('https://conda.anaconda.org/main/'): yarl.URL('https://repo.anaconda.com/pkgs/main'),
+        yarl.URL("https://conda.anaconda.org/main/"): yarl.URL(
+            "https://repo.anaconda.com/pkgs/main"
+        ),
     }
     channel_url = channel_replacements.get(yarl.URL(channel), yarl.URL(channel))
 
@@ -69,7 +71,7 @@ def download_repodata(
         response = requests.get(
             channel_url / subdir / "repodata.json.bz2", headers=headers
         )
-        if response.status_code == 304: # 304 Not Modified since last_update
+        if response.status_code == 304:  # 304 Not Modified since last_update
             continue
         response.raise_for_status()
         repodata["architectures"][subdir] = json.loads(bz2.decompress(response.content))

--- a/conda-store-server/conda_store_server/conda.py
+++ b/conda-store-server/conda_store_server/conda.py
@@ -45,11 +45,11 @@ def download_repodata(
     # the https://conda.anaconda.org/<channel>/channeldata.json
     # so we replace the given url with it's equivalent alias
     channel_replacements = {
-        yarl.URL("https://conda.anaconda.org/main/"): yarl.URL(
-            "https://repo.anaconda.com/pkgs/main"
-        ),
+        "https://conda.anaconda.org/main/": yarl.URL("https://repo.anaconda.com/pkgs/main")
     }
-    channel_url = channel_replacements.get(yarl.URL(channel), yarl.URL(channel))
+    normalized_channel_url = yarl.URL(channel) / "./"
+    channel_url = channel_replacements.get(
+        str(normalized_channel_url), yarl.URL(channel))
 
     headers = {}
     if last_update:
@@ -62,7 +62,7 @@ def download_repodata(
 
     response = requests.get(channel_url / "channeldata.json", headers=headers)
     if response.status_code == 304:  # 304 Not Modified since last_update
-        return {}
+        return {'architectures': {}}
     response.raise_for_status()
 
     repodata = response.json()

--- a/conda-store-server/conda_store_server/conda.py
+++ b/conda-store-server/conda_store_server/conda.py
@@ -45,11 +45,14 @@ def download_repodata(
     # the https://conda.anaconda.org/<channel>/channeldata.json
     # so we replace the given url with it's equivalent alias
     channel_replacements = {
-        "https://conda.anaconda.org/main/": yarl.URL("https://repo.anaconda.com/pkgs/main")
+        "https://conda.anaconda.org/main/": yarl.URL(
+            "https://repo.anaconda.com/pkgs/main"
+        )
     }
     normalized_channel_url = yarl.URL(channel) / "./"
     channel_url = channel_replacements.get(
-        str(normalized_channel_url), yarl.URL(channel))
+        str(normalized_channel_url), yarl.URL(channel)
+    )
 
     headers = {}
     if last_update:
@@ -62,7 +65,7 @@ def download_repodata(
 
     response = requests.get(channel_url / "channeldata.json", headers=headers)
     if response.status_code == 304:  # 304 Not Modified since last_update
-        return {'architectures': {}}
+        return {"architectures": {}}
     response.raise_for_status()
 
     repodata = response.json()

--- a/conda-store-server/conda_store_server/orm.py
+++ b/conda-store-server/conda_store_server/orm.py
@@ -271,11 +271,8 @@ class CondaChannel(Base):
     name = Column(Unicode(255), unique=True, nullable=False)
     last_update = Column(DateTime)
 
-    def update_packages(self, db):
-        repodata = download_repodata(self.name, self.last_update)
-        if not repodata:
-            # nothing to update
-            return
+    def update_packages(self, db, subdirs=None):
+        repodata = download_repodata(self.name, self.last_update, subdirs=subdirs)
 
         for architecture in repodata["architectures"]:
             packages = list(

--- a/conda-store-server/conda_store_server/schema.py
+++ b/conda-store-server/conda_store_server/schema.py
@@ -112,7 +112,7 @@ class Environment(BaseModel):
 
 # Conda Environment
 class CondaSpecificationPip(BaseModel):
-    pip: List[str]
+    pip: List[str] = []
 
     @validator("pip", each_item=True)
     def check_pip(cls, v):
@@ -126,8 +126,8 @@ class CondaSpecificationPip(BaseModel):
 
 class CondaSpecification(BaseModel):
     name: constr(regex=f"^[{ALLOWED_CHARACTERS}]+$")  # noqa: F722
-    channels: Optional[List[str]] = []
-    dependencies: List[Union[str, CondaSpecificationPip]]
+    channels: List[str] = []
+    dependencies: List[Union[str, CondaSpecificationPip]] = []
     prefix: Optional[str]
 
     @validator("dependencies", each_item=True)

--- a/conda-store-server/conda_store_server/worker/tasks.py
+++ b/conda-store-server/conda_store_server/worker/tasks.py
@@ -58,14 +58,13 @@ def task_update_conda_channels(self):
         conda_store.ensure_conda_channels()
 
         for channel in api.list_conda_channels(conda_store.db):
-            channel.update_packages(conda_store.db)
+            channel.update_packages(conda_store.db, subdirs=conda_store.conda_platforms)
     except IntegrityError as exc:
-        # there is a persistent error on startup
-        # that when the conda channels are out of data
-        # and two tasks try to add the same packages
-        # it runs into integrity errors
-        # the solution is to let one of them finish
-        # and the other try again at a later time
+        # there is a persistent error on startup that when the conda
+        # channels are out of data and two tasks try to add the same
+        # packages it runs into integrity errors the solution is to
+        # let one of them finish and the other try again at a later
+        # time
         self.retry(exc=exc, countdown=random.randrange(15, 30))
 
 

--- a/docs/administration.md
+++ b/docs/administration.md
@@ -117,10 +117,30 @@ usually result in lower peak memory usage and faster builds.
 shorthand Conda channels that do not specify a url. The default is
 `https://conda.anaconda.org`.
 
+`CondaStore.conda_platforms` are the platforms to download package
+repodata.json from. By default includes current architecture and
+`noarch`.
+
+`CondaStore.conda_default_channels` is a list of Conda channels that
+are by default added if channels within the specification is empty.
+
 `CondaStore.conda_allowed_channels` is a list of Conda channels that
-are allowed (currently not enforced). This also tells Conda-Store
-which channels to prefetch the channel repodata from. The default is
-`https://repo.anaconda.com/pkgs/main` and `conda-forge`.
+are allowed. This also tells Conda-Store which channels to prefetch
+the channel `repodata` and `channeldata` from. The default is `main` and
+`conda-forge`.
+
+`CondaStore.conda_default_packages` is a list of Conda packages that
+are included by default if none are specified within the specification
+dependencies.
+
+`CondaStore.conda_required_packages` is a list of Conda packages that
+are required upon validation of the specification dependencies. This
+will not auto add the packages but instead throw an error that they
+are missing.
+
+`CondaStore.conda_included_packages` is a list of Conda packages that
+if not specified within the specification dependencies will be auto
+added.
 
 `CondaStore.database_url` is the url string for connecting to the
 database. Behind the scenes [SQLAlchemy](https://www.sqlalchemy.org/)

--- a/tests/assets/conda_store_config.py
+++ b/tests/assets/conda_store_config.py
@@ -14,15 +14,9 @@ c.CondaStore.database_url = "postgresql+psycopg2://admin:password@postgres/conda
 c.CondaStore.default_uid = 1000
 c.CondaStore.default_gid = 100
 c.CondaStore.default_permissions = "775"
-
-
-def validate_specification(conda_store, specification):
-    has_ipykernel = any(('ipykernel' in _) for _ in specification.dependencies)
-    if not has_ipykernel:
-        specification.dependencies.append('ipykernel')
-    return specification
-
-c.CondaStore.validate_specification = validate_specification
+c.CondaStore.conda_included_packages = [
+    'ipykernel'
+]
 
 
 c.S3Storage.internal_endpoint = "minio:9000"


### PR DESCRIPTION
In PR #252 a function was added to allow for arbitrary modification and validation of the specification. This PR aims to enhance this feature with additional settings to allow for easy validation/modifications of specifications.

Via:
 - `CondaStore.conda_default_channels`
 - `CondaStore.conda_allowed_channels`
 - `CondaStore.conda_default_packages`
 - `CondaStore.conda_required_packages`
 - `CondaStore.conda_included_packages`

Additionally `conda_allowed_channels` is now enforced and packages cannot be fetched from channels not in this list.

Closes #253 