### PR TITLE
Fix #263 : exact search

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ docs/_build
 
 # nix
 .direnv
+**/.DS_Store

--- a/conda-store-server/conda_store_server/api.py
+++ b/conda-store-server/conda_store_server/api.py
@@ -110,11 +110,13 @@ def get_build(db, build_id: int):
     return db.query(orm.Build).filter(orm.Build.id == build_id).first()
 
 
-def get_build_packages(db, build_id: int, search: str = None, exact: bool = False, build: str = None):
+def get_build_packages(
+    db, build_id: int, search: str = None, exact: bool = False, build: str = None
+):
     filters = [(orm.build_conda_package.c.build_id == build_id)]
     if search:
         if exact:
-            filters.append(orm.CondaPackage.name.like(search.replace("%", "\%") ))
+            filters.append(orm.CondaPackage.name.like(search.replace("%", "\%")))
         else:
             filters.append(orm.CondaPackage.name.contains(search, autoescape=True))
     if build:
@@ -192,7 +194,7 @@ def list_conda_packages(db, search: str = None, exact: bool = False, build: str 
     filters = []
     if search:
         if exact:
-            filters.append(orm.CondaPackage.name.like(search.replace("%", "\%") ))
+            filters.append(orm.CondaPackage.name.like(search.replace("%", "\%")))
         else:
             filters.append(orm.CondaPackage.name.contains(search, autoescape=True))
     if build:

--- a/conda-store-server/conda_store_server/api.py
+++ b/conda-store-server/conda_store_server/api.py
@@ -110,10 +110,13 @@ def get_build(db, build_id: int):
     return db.query(orm.Build).filter(orm.Build.id == build_id).first()
 
 
-def get_build_packages(db, build_id: int, search: str = None, build: str = None):
+def get_build_packages(db, build_id: int, search: str = None, exact: bool = False, build: str = None):
     filters = [(orm.build_conda_package.c.build_id == build_id)]
     if search:
-        filters.append(orm.CondaPackage.name.contains(search, autoescape=True))
+        if exact:
+            filters.append(orm.CondaPackage.name.like(search.replace("%", "\%") ))
+        else:
+            filters.append(orm.CondaPackage.name.contains(search, autoescape=True))
     if build:
         filters.append(orm.CondaPackage.build.contains(build, autoescape=True))
 
@@ -185,10 +188,13 @@ def get_conda_channel(db, channel_name: str):
     )
 
 
-def list_conda_packages(db, search: str = None, build: str = None):
+def list_conda_packages(db, search: str = None, exact: bool = False, build: str = None):
     filters = []
     if search:
-        filters.append(orm.CondaPackage.name.contains(search, autoescape=True))
+        if exact:
+            filters.append(orm.CondaPackage.name.like(search.replace("%", "\%") ))
+        else:
+            filters.append(orm.CondaPackage.name.contains(search, autoescape=True))
     if build:
         filters.append(orm.CondaPackage.build.contains(build, autoescape=True))
 

--- a/conda-store-server/conda_store_server/api.py
+++ b/conda-store-server/conda_store_server/api.py
@@ -116,7 +116,7 @@ def get_build_packages(
     filters = [(orm.build_conda_package.c.build_id == build_id)]
     if search:
         if exact:
-            filters.append(orm.CondaPackage.name.like(search.replace("%", "\%")))
+            filters.append(orm.CondaPackage.name.like(search.replace("%", r"\%")))
         else:
             filters.append(orm.CondaPackage.name.contains(search, autoescape=True))
     if build:
@@ -194,7 +194,7 @@ def list_conda_packages(db, search: str = None, exact: bool = False, build: str 
     filters = []
     if search:
         if exact:
-            filters.append(orm.CondaPackage.name.like(search.replace("%", "\%")))
+            filters.append(orm.CondaPackage.name.like(search.replace("%", r"\%")))
         else:
             filters.append(orm.CondaPackage.name.contains(search, autoescape=True))
     if build:

--- a/conda-store-server/conda_store_server/server/views/api.py
+++ b/conda-store-server/conda_store_server/server/views/api.py
@@ -389,9 +389,11 @@ def api_get_build_packages(build_id):
     )
 
     search = request.args.get("search")
+    exact = request.args.get("exact")
+    
     build_str = request.args.get("build")
     orm_packages = api.get_build_packages(
-        conda_store.db, build.id, search=search, build=build_str
+        conda_store.db, build.id, search=search, exact=exact, build=build_str
     )
     return paginated_api_response(
         orm_packages,
@@ -441,9 +443,11 @@ def api_list_packages():
     conda_store = get_conda_store()
 
     search = request.args.get("search")
+    exact = request.args.get("exact")
+    
     build = request.args.get("build")
 
-    orm_packages = api.list_conda_packages(conda_store.db, search=search, build=build)
+    orm_packages = api.list_conda_packages(conda_store.db, search=search, exact=exact, build=build)
     required_sort_bys, distinct_orm_packages = filter_distinct_on(
         orm_packages,
         allowed_distinct_ons={

--- a/conda-store-server/conda_store_server/server/views/api.py
+++ b/conda-store-server/conda_store_server/server/views/api.py
@@ -390,7 +390,7 @@ def api_get_build_packages(build_id):
 
     search = request.args.get("search")
     exact = request.args.get("exact")
-    
+
     build_str = request.args.get("build")
     orm_packages = api.get_build_packages(
         conda_store.db, build.id, search=search, exact=exact, build=build_str
@@ -444,10 +444,12 @@ def api_list_packages():
 
     search = request.args.get("search")
     exact = request.args.get("exact")
-    
+
     build = request.args.get("build")
 
-    orm_packages = api.list_conda_packages(conda_store.db, search=search, exact=exact, build=build)
+    orm_packages = api.list_conda_packages(
+        conda_store.db, search=search, exact=exact, build=build
+    )
     required_sort_bys, distinct_orm_packages = filter_distinct_on(
         orm_packages,
         allowed_distinct_ons={

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -179,7 +179,7 @@ rerender`. An example of this can be found in [PR
    - `build` string to search within `build` for example strings include
      `py27_0` etc which can be useful for filtering specific versions of
      packages.
-   - `search` will search within the package names for a match
+   - `search` will search within the package names for a match. The search is fuzzy by default. To get the packages with the exact given name, add the parameter `exact=1`.
 
 ### Conda Channels
 
@@ -193,7 +193,7 @@ rerender`. An example of this can be found in [PR
    - `build` string to search within `build` for example strings include
      `py27_0` etc which can be useful for filtering specific versions of
      packages.
-   - `search` will search within the package names for a match
+   - `search` will search within the package names for a match. The search is fuzzy by default. To get the packages with the exact given name, add the parameter `exact=1`.
 
 ### REST API query format
 


### PR DESCRIPTION
Here is the work to have an exact search in the api for the two packages endpoints : `/api/v1/package` and `/api/v1/build/<build-id>/packages/`.

As explained in the issue #263, I chose to use an `exact` parameter, complementary to `search`, instead of the alternative design (have `search` and `name` parameters, which would imply to choose arbitrarily between one of the two when both parameters are given)

I tested it manually with an env containing `pandas` and `pandas_schema` and querying the API accordingly.

The only solution I found with sqlalchemy to achieve exact match is to use the `like` operator, forcing me to replace occurences of `%`.
