### PR TITLE
Fix #294 : yaml spec file uses pip options

### DIFF
--- a/conda-store-server/conda_store_server/environment.py
+++ b/conda-store-server/conda_store_server/environment.py
@@ -101,11 +101,11 @@ def validate_environment_pypi_packages(
     required_packages: List[str],
 ) -> schema.Specification:
     def _package_names(packages):
-        
+
         result = {}
         for p in packages:
-            if isinstance(p, str) and not p.startswith('--'):
-                result[ Requirement.parse(p).name ] = p
+            if isinstance(p, str) and not p.startswith("--"):
+                result[Requirement.parse(p).name] = p
         return result
 
     def _get_pip_packages(specification):

--- a/conda-store-server/conda_store_server/environment.py
+++ b/conda-store-server/conda_store_server/environment.py
@@ -101,7 +101,12 @@ def validate_environment_pypi_packages(
     required_packages: List[str],
 ) -> schema.Specification:
     def _package_names(packages):
-        return {Requirement.parse(_).name: _ for _ in packages if isinstance(_, str)}
+        
+        result = {}
+        for p in packages:
+            if isinstance(p, str) and not p.startswith('--'):
+                result[ Requirement.parse(p).name ] = p
+        return result
 
     def _get_pip_packages(specification):
         for package in specification.dependencies:

--- a/conda-store-server/conda_store_server/environment.py
+++ b/conda-store-server/conda_store_server/environment.py
@@ -101,7 +101,6 @@ def validate_environment_pypi_packages(
     required_packages: List[str],
 ) -> schema.Specification:
     def _package_names(packages):
-
         result = {}
         for p in packages:
             if isinstance(p, str) and not p.startswith("--"):

--- a/conda-store-server/conda_store_server/schema.py
+++ b/conda-store-server/conda_store_server/schema.py
@@ -144,7 +144,7 @@ class CondaSpecificationPip(BaseModel):
     @validator("pip", each_item=True)
     def check_pip(cls, v):
 
-        allowed_pip_params = ["--index-url", "--extra-urls", "--trusted-urls"]
+        allowed_pip_params = ["--index-url", "--extra-index-url", "--trusted-host"]
 
         try:
             if v is not None and not v.startswith("--"):

--- a/conda-store-server/conda_store_server/schema.py
+++ b/conda-store-server/conda_store_server/schema.py
@@ -143,16 +143,14 @@ class CondaSpecificationPip(BaseModel):
 
     @validator("pip", each_item=True)
     def check_pip(cls, v):
-    
-        allowed_pip_params = ["--index-url",
-                                "--extra-urls",
-                                "--trusted-urls"]
-    
+
+        allowed_pip_params = ["--index-url", "--extra-urls", "--trusted-urls"]
+
         try:
             if v is not None and not v.startswith("--"):
                 Requirement.parse(v)
             elif v is not None and v.startswith("--"):
-                pip_param, _  = v.split(" ")
+                pip_param, _ = v.split(" ")
 
                 if pip_param not in allowed_pip_params:
                     raise Exception(f"Invalid pip param {pip_param}")
@@ -161,7 +159,6 @@ class CondaSpecificationPip(BaseModel):
             raise ValueError(f"Invalid pypi package dependency {v}")
 
         return v
-    
 
 
 class CondaSpecification(BaseModel):

--- a/conda-store-server/conda_store_server/schema.py
+++ b/conda-store-server/conda_store_server/schema.py
@@ -143,12 +143,25 @@ class CondaSpecificationPip(BaseModel):
 
     @validator("pip", each_item=True)
     def check_pip(cls, v):
+    
+        allowed_pip_params = ["--index-url",
+                                "--extra-urls",
+                                "--trusted-urls"]
+    
         try:
-            Requirement.parse(v)
+            if v is not None and not v.startswith("--"):
+                Requirement.parse(v)
+            elif v is not None and v.startswith("--"):
+                pip_param, _  = v.split(" ")
+
+                if pip_param not in allowed_pip_params:
+                    raise Exception(f"Invalid pip param {pip_param}")
+
         except Exception:
             raise ValueError(f"Invalid pypi package dependency {v}")
 
         return v
+    
 
 
 class CondaSpecification(BaseModel):

--- a/conda-store-server/conda_store_server/schema.py
+++ b/conda-store-server/conda_store_server/schema.py
@@ -148,7 +148,7 @@ class CondaSpecificationPip(BaseModel):
         allowed_pip_params = ["--index-url", "--extra-index-url", "--trusted-host"]
 
         if v.startswith("--"):
-            match = re.fullmatch("(.+)[ =](.+)", v)
+            match = re.fullmatch("(.+?)[ =](.*)", v)
             if match is None or match.group(1) not in allowed_pip_params:
                 raise ValueError(
                     f"Invalid pip option '{v}' supported options are {allowed_pip_params}"

--- a/conda-store-server/conda_store_server/schema.py
+++ b/conda-store-server/conda_store_server/schema.py
@@ -1,3 +1,4 @@
+import re
 import datetime
 import enum
 from typing import List, Optional, Union, Dict, Any
@@ -146,17 +147,15 @@ class CondaSpecificationPip(BaseModel):
 
         allowed_pip_params = ["--index-url", "--extra-index-url", "--trusted-host"]
 
-        try:
-            if v is not None and not v.startswith("--"):
+        if v.startswith("--"):
+            match = re.fullmatch('(.+)[ =](.+)', v)
+            if match is None or match.group(1) not in allowed_pip_params:
+                raise ValueError(f"Invalid pip option '{v}' supported options are {allowed_pip_params}")
+        else:
+            try:
                 Requirement.parse(v)
-            elif v is not None and v.startswith("--"):
-                pip_param, _ = v.split(" ")
-
-                if pip_param not in allowed_pip_params:
-                    raise Exception(f"Invalid pip param {pip_param}")
-
-        except Exception:
-            raise ValueError(f"Invalid pypi package dependency {v}")
+            except Exception:
+                raise ValueError(f"Invalid pypi package dependency {v}")
 
         return v
 

--- a/conda-store-server/conda_store_server/schema.py
+++ b/conda-store-server/conda_store_server/schema.py
@@ -148,9 +148,11 @@ class CondaSpecificationPip(BaseModel):
         allowed_pip_params = ["--index-url", "--extra-index-url", "--trusted-host"]
 
         if v.startswith("--"):
-            match = re.fullmatch('(.+)[ =](.+)', v)
+            match = re.fullmatch("(.+)[ =](.+)", v)
             if match is None or match.group(1) not in allowed_pip_params:
-                raise ValueError(f"Invalid pip option '{v}' supported options are {allowed_pip_params}")
+                raise ValueError(
+                    f"Invalid pip option '{v}' supported options are {allowed_pip_params}"
+                )
         else:
             try:
                 Requirement.parse(v)

--- a/conda-store-server/conda_store_server/server/views/api.py
+++ b/conda-store-server/conda_store_server/server/views/api.py
@@ -416,7 +416,7 @@ def api_post_specification(
     except yaml.error.YAMLError:
         raise HTTPException(status_code=400, detail="Unable to parse. Invalid YAML")
     except pydantic.ValidationError as e:
-        raise HTTPException(status_code=400, default=str(e))
+        raise HTTPException(status_code=400, detail=str(e))
 
     auth.authorize_request(
         request,


### PR DESCRIPTION
Fix #294 : Yaml spec file uses pip options.

Tests : 

- First, I've tried a public pypi mirror : 

```yaml
channels:
- conda-forge
dependencies:
- python=3.6
- pandas
- ipykernel
- pip
- pip:
  - --index-url https://mirrors.sustech.edu.cn/pypi/simple
  - flask
name: test_env_3
prefix: null
```
Setting up a pypi mirror is cumbersome. either I use bandersnatch but it requires 250GB (which I haven't), or [this repo](https://github.com/montag451/pypi-mirror) but it doesn't provide wheels. So for the sake of progressing faster, I've used a public mirror. 
This yaml works and builds.


```yaml
channels:
- conda-forge
dependencies:
- python=3.6
- pandas
- ipykernel
- pip
- pip:
  - --index-url https://mirrors.sustech.edu.cn/pypi/simple
  - --test quansight
  - flask
name: test_env_3
prefix: null
``` 
This one doesn't work, as this is expected due to the unallowed pip parameter "--test".


