### PR TITLE
More pip fixes

### DIFF
--- a/conda-store-server/conda_store_server/environment.py
+++ b/conda-store-server/conda_store_server/environment.py
@@ -112,16 +112,16 @@ def validate_environment_pypi_packages(
 
     def _get_pip_packages(specification):
         for package in specification.dependencies:
-            if isinstance(package, dict) and "pip" in package:
-                return package
+            if isinstance(package, schema.CondaSpecificationPip):
+                return package.pip
         return []
 
     def _append_pip_packages(specification, packages):
         for package in specification.dependencies:
-            if isinstance(package, dict) and "pip" in package:
-                package["pip"] += packages
+            if isinstance(package, schema.CondaSpecificationPip):
+                package.pip += packages
                 return
-        specification.dependencies.append({"pip": packages})
+        specification.dependencies.append(schema.CondaSpecificationPip(pip=packages))
 
     if len(_get_pip_packages(specification)) == 0 and len(default_packages) != 0:
         _append_pip_packages(specification, default_packages)


### PR DESCRIPTION
Weird thing, I swear I had seen an error about `'dict' object has no attribute 'extend'` before, indicating that the pip dependencies was a dict, but....

Actually it looks like the pip dependencies will be a `schema.CondaSpecificationPip`, not a dict.

This fixes an issue we were seeing when using `c.CondaStore.pypi_included_packages`:

- If a `pip:` section existed in the original yaml, a second `pip:` section would be
added with the 'included' packages rather than appening to the original `pip:` section.
For example, creating an environment with this yaml:
  ```
  dependencies:
    - pip:
      - requests
  ```
  And this config:
  ```
  c.CondaStore.pypi_included_packages = ["pandas"]
  ```
  Would result in this:
  ```
  dependencies:
    - pip:
      - requests
    - pip:
      - pandas
  ```