### PR TITLE
Change build id from integer to uuid representation

### DIFF
--- a/conda-store-server/conda_store_server/api.py
+++ b/conda-store-server/conda_store_server/api.py
@@ -1,5 +1,6 @@
 from typing import List
 import re
+import uuid
 
 from sqlalchemy import func, null
 
@@ -116,12 +117,12 @@ def list_builds(db, status: schema.BuildStatus = None, show_soft_deleted: bool =
     return db.query(orm.Build).filter(*filters)
 
 
-def get_build(db, build_id: int):
+def get_build(db, build_id: uuid.UUID):
     return db.query(orm.Build).filter(orm.Build.id == build_id).first()
 
 
 def get_build_packages(
-    db, build_id: int, search: str = None, exact: bool = False, build: str = None
+    db, build_id: uuid.UUID, search: str = None, exact: bool = False, build: str = None
 ):
     filters = [(orm.build_conda_package.c.build_id == build_id)]
     if search:
@@ -140,7 +141,7 @@ def get_build_packages(
     )
 
 
-def get_build_lockfile(db, build_id: int):
+def get_build_lockfile(db, build_id: uuid.UUID):
     build = db.query(orm.Build).filter(orm.Build.id == build_id).first()
     packages = [
         f"{row.channel.name}/{row.subdir}/{row.name}-{row.version}-{row.build}.tar.bz2#{row.md5}"
@@ -154,7 +155,7 @@ def get_build_lockfile(db, build_id: int):
     )
 
 
-def get_build_artifact_types(db, build_id: int):
+def get_build_artifact_types(db, build_id: uuid.UUID):
     return (
         db.query(orm.BuildArtifact.artifact_type)
         .filter(orm.BuildArtifact.build_id == build_id)
@@ -164,7 +165,7 @@ def get_build_artifact_types(db, build_id: int):
 
 def list_build_artifacts(
     db,
-    build_id: int = None,
+    build_id: uuid.UUID = None,
     key: str = None,
     excluded_artifact_types: List[schema.BuildArtifactType] = None,
 ):
@@ -181,7 +182,7 @@ def list_build_artifacts(
     return db.query(orm.BuildArtifact).filter(*filters)
 
 
-def get_build_artifact(db, build_id: int, key: str):
+def get_build_artifact(db, build_id: uuid.UUID, key: str):
     return (
         db.query(orm.BuildArtifact)
         .filter(orm.BuildArtifact.build_id == build_id, orm.BuildArtifact.key == key)

--- a/conda-store-server/conda_store_server/orm.py
+++ b/conda-store-server/conda_store_server/orm.py
@@ -42,11 +42,12 @@ class GUID(TypeDecorator):
     CHAR(32), storing as stringified hex values.
 
     """
+
     impl = CHAR
     cache_ok = True
 
     def load_dialect_impl(self, dialect):
-        if dialect.name == 'postgresql':
+        if dialect.name == "postgresql":
             return dialect.type_descriptor(UUID())
         else:
             return dialect.type_descriptor(CHAR(32))
@@ -54,7 +55,7 @@ class GUID(TypeDecorator):
     def process_bind_param(self, value, dialect):
         if value is None:
             return value
-        elif dialect.name == 'postgresql':
+        elif dialect.name == "postgresql":
             return str(value)
         else:
             if not isinstance(value, uuid.UUID):

--- a/conda-store-server/conda_store_server/server/views/api.py
+++ b/conda-store-server/conda_store_server/server/views/api.py
@@ -1,4 +1,5 @@
 from typing import List, Dict, Optional
+import uuid
 
 import pydantic
 import yaml
@@ -317,7 +318,7 @@ def api_update_environment_build(
     request: Request,
     conda_store=Depends(dependencies.get_conda_store),
     auth=Depends(dependencies.get_auth),
-    build_id: int = Body(..., embed=True),
+    build_id: uuid.UUID = Body(..., embed=True),
 ):
     auth.authorize_request(
         request, f"{namespace}/{name}", {Permissions.ENVIRONMENT_UPDATE}, require=True
@@ -457,7 +458,7 @@ def api_list_builds(
 
 @router_api.get("/build/{build_id}/", response_model=schema.APIGetBuild)
 def api_get_build(
-    build_id: int,
+    build_id: uuid.UUID,
     request: Request,
     conda_store=Depends(dependencies.get_conda_store),
     auth=Depends(dependencies.get_auth),
@@ -484,7 +485,7 @@ def api_get_build(
     response_model=schema.APIPostSpecification,
 )
 def api_put_build(
-    build_id: int,
+    build_id: uuid.UUID,
     request: Request,
     conda_store=Depends(dependencies.get_conda_store),
     auth=Depends(dependencies.get_auth),
@@ -515,7 +516,7 @@ def api_put_build(
     response_model=schema.APIAckResponse,
 )
 def api_delete_build(
-    build_id: int,
+    build_id: uuid.UUID,
     request: Request,
     conda_store=Depends(dependencies.get_conda_store),
     auth=Depends(dependencies.get_auth),
@@ -544,7 +545,7 @@ def api_delete_build(
     response_model=schema.APIListCondaPackage,
 )
 def api_get_build_packages(
-    build_id: int,
+    build_id: uuid.UUID,
     request: Request,
     search: Optional[str] = None,
     exact: Optional[str] = None,
@@ -581,7 +582,7 @@ def api_get_build_packages(
 
 @router_api.get("/build/{build_id}/logs/")
 def api_get_build_logs(
-    build_id: int,
+    build_id: uuid.UUID,
     request: Request,
     conda_store=Depends(dependencies.get_conda_store),
     auth=Depends(dependencies.get_auth),
@@ -660,7 +661,7 @@ def api_list_packages(
 
 @router_api.get("/build/{build_id}/yaml/")
 def api_get_build_yaml(
-    build_id: int,
+    build_id: uuid.UUID,
     request: Request,
     conda_store=Depends(dependencies.get_conda_store),
     auth=Depends(dependencies.get_auth),

--- a/conda-store-server/conda_store_server/server/views/ui.py
+++ b/conda-store-server/conda_store_server/server/views/ui.py
@@ -1,3 +1,5 @@
+import uuid
+
 from fastapi import APIRouter, Request, Depends
 from fastapi.responses import RedirectResponse, PlainTextResponse
 import yaml
@@ -168,7 +170,7 @@ def ui_edit_environment(
 
 @router_ui.get("/build/{build_id}/")
 def ui_get_build(
-    build_id: int,
+    build_id: uuid.UUID,
     request: Request,
     templates=Depends(dependencies.get_templates),
     conda_store=Depends(dependencies.get_conda_store),
@@ -231,7 +233,7 @@ def ui_get_user(
 
 @router_ui.get("/build/{build_id}/logs/")
 def api_get_build_logs(
-    build_id: int,
+    build_id: uuid.UUID,
     request: Request,
     conda_store=Depends(dependencies.get_conda_store),
     auth=Depends(dependencies.get_auth),
@@ -249,7 +251,7 @@ def api_get_build_logs(
 
 @router_ui.get("/build/{build_id}/lockfile/", response_class=PlainTextResponse)
 def api_get_build_lockfile(
-    build_id: int,
+    build_id: uuid.UUID,
     request: Request,
     conda_store=Depends(dependencies.get_conda_store),
     auth=Depends(dependencies.get_auth),
@@ -268,7 +270,7 @@ def api_get_build_lockfile(
 
 @router_ui.get("/build/{build_id}/archive/")
 def api_get_build_archive(
-    build_id: int,
+    build_id: uuid.UUID,
     request: Request,
     conda_store=Depends(dependencies.get_conda_store),
     auth=Depends(dependencies.get_auth),

--- a/conda-store-server/conda_store_server/worker/tasks.py
+++ b/conda-store-server/conda_store_server/worker/tasks.py
@@ -50,8 +50,8 @@ def task_watch_builds(self):
 
     for build in api.list_builds(conda_store.db, status=schema.BuildStatus.BUILDING):
         result = AsyncResult(str(build.id))
-        if result.status == 'PENDING':
-            set_build_failed(conda_store, build, b'Build lost in BUILDING state\n')
+        if result.status == "PENDING":
+            set_build_failed(conda_store, build, b"Build lost in BUILDING state\n")
 
 
 @current_app.task(base=WorkerTask, name="task_watch_paths", bind=True)

--- a/flake.nix
+++ b/flake.nix
@@ -28,6 +28,8 @@
           pythonPackages.celery
           pythonPackages.uvicorn
           pythonPackages.fastapi
+          pythonPackages.sqlalchemy
+          pythonPackages.redis
           pythonPackages.pyjwt
           pythonPackages.minio
           pythonPackages.filelock


### PR DESCRIPTION
Several reasons for this PR:
 - build id as an integer gives non-user friendly ids
 - wanting to follow a model similar to uploading docker images/tags
 to docker hub this should allow making it easier to mirror
 - correlating task ids to celery tasks to monitor progress if lost
 
Merge after #314 and use alembic for the migration changing the build_id type.