### PR TITLE
Add `POSTGRES_USER` env var back into docker example

### DIFF
--- a/examples/docker/docker-compose.yaml
+++ b/examples/docker/docker-compose.yaml
@@ -119,6 +119,7 @@ services:
       timeout: 5s
       retries: 5
     environment:
+      POSTGRES_USER: postgres
       POSTGRES_PASSWORD: password
       POSTGRES_DB: conda-store
 


### PR DESCRIPTION
This PR adds back in a `POSTGRES_USER` environment variable into `examples/docker/docker-compose.yaml` to ensure that a `postgres` user is created when the docker image is run. Without this change the docker container fails to run. Resolves #318.

I've tested this manually to make sure it works, but would appreciate feedback.