### PR TITLE
Added namespace query parameter to /api/v1/environment/?namespace=<namespace>

### DIFF
--- a/conda-store-server/conda_store_server/api.py
+++ b/conda-store-server/conda_store_server/api.py
@@ -1,7 +1,7 @@
 from typing import List
 import re
 
-from sqlalchemy import func, null
+from sqlalchemy import func, null, or_
 
 from conda_store_server import orm, schema
 from conda_store_server.conda import conda_platform
@@ -46,15 +46,25 @@ def delete_namespace(db, name: str = None, id: int = None):
 def list_environments(
     db,
     namespace: str = None,
+    name: str = None,
     search: str = None,
     show_soft_deleted: bool = False,
 ):
     filters = []
+
     if namespace:
         filters.append(orm.Namespace.name == namespace)
 
+    if name:
+        filters.append(orm.Environment.name == name)
+
     if search:
-        filters.append(orm.Environment.name.contains(search, autoescape=True))
+        filters.append(
+            or_(
+                orm.Namespace.name.contains(search, autoescape=True),
+                orm.Environment.name.contains(search, autoescape=True),
+            )
+        )
 
     if not show_soft_deleted:
         filters.append(orm.Environment.deleted_on == null())

--- a/conda-store-server/conda_store_server/server/views/api.py
+++ b/conda-store-server/conda_store_server/server/views/api.py
@@ -253,6 +253,8 @@ def api_delete_namespace(
 )
 def api_list_environments(
     search: Optional[str] = None,
+    namespace: Optional[str] = None,
+    name: Optional[str] = None,
     conda_store=Depends(dependencies.get_conda_store),
     auth=Depends(dependencies.get_auth),
     entity=Depends(dependencies.get_entity),
@@ -260,7 +262,13 @@ def api_list_environments(
 ):
     orm_environments = auth.filter_environments(
         entity,
-        api.list_environments(conda_store.db, search=search, show_soft_deleted=False),
+        api.list_environments(
+            conda_store.db,
+            search=search,
+            namespace=namespace,
+            name=name,
+            show_soft_deleted=False,
+        ),
     )
     return paginated_api_response(
         orm_environments,

--- a/conda-store-server/conda_store_server/server/views/ui.py
+++ b/conda-store-server/conda_store_server/server/views/ui.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from fastapi import APIRouter, Request, Depends
 from fastapi.responses import RedirectResponse, PlainTextResponse
 import yaml
@@ -44,6 +46,7 @@ def ui_create_get_environment(
 @router_ui.get("/")
 def ui_list_environments(
     request: Request,
+    search: Optional[str] = None,
     templates=Depends(dependencies.get_templates),
     conda_store=Depends(dependencies.get_conda_store),
     auth=Depends(dependencies.get_auth),
@@ -51,7 +54,8 @@ def ui_list_environments(
     entity=Depends(dependencies.get_entity),
 ):
     orm_environments = auth.filter_environments(
-        entity, api.list_environments(conda_store.db, show_soft_deleted=False)
+        entity,
+        api.list_environments(conda_store.db, search=search, show_soft_deleted=False),
     )
 
     context = {


### PR DESCRIPTION
Closes #323

Additionally:
 - search in environment now considers the namespace
 - name is an additional allowed query parameter
 - search query parameter is allowed in `/` home