### PR TITLE
API builds/environments filter on packages, status

### DIFF
--- a/conda-store-server/conda_store_server/server/views/api.py
+++ b/conda-store-server/conda_store_server/server/views/api.py
@@ -257,6 +257,7 @@ def api_list_environments(
     name: Optional[str] = None,
     status: Optional[schema.BuildStatus] = None,
     packages: Optional[List[str]] = Query([]),
+    artifact: Optional[schema.BuildArtifactType] = None,
     conda_store=Depends(dependencies.get_conda_store),
     auth=Depends(dependencies.get_auth),
     entity=Depends(dependencies.get_entity),
@@ -271,6 +272,7 @@ def api_list_environments(
             name=name,
             status=status,
             packages=packages,
+            artifact=artifact,
             show_soft_deleted=False,
         ),
     )
@@ -449,6 +451,7 @@ def api_post_specification(
 def api_list_builds(
     status: Optional[schema.BuildStatus] = None,
     packages: Optional[List[str]] = Query([]),
+    artifact: Optional[schema.BuildArtifactType] = None,
     conda_store=Depends(dependencies.get_conda_store),
     auth=Depends(dependencies.get_auth),
     entity=Depends(dependencies.get_entity),
@@ -457,7 +460,11 @@ def api_list_builds(
     orm_builds = auth.filter_builds(
         entity,
         api.list_builds(
-            conda_store.db, status=status, packages=packages, show_soft_deleted=True
+            conda_store.db,
+            status=status,
+            packages=packages,
+            artifact=artifact,
+            show_soft_deleted=True,
         ),
     )
     return paginated_api_response(

--- a/conda-store-server/conda_store_server/server/views/api.py
+++ b/conda-store-server/conda_store_server/server/views/api.py
@@ -255,6 +255,8 @@ def api_list_environments(
     search: Optional[str] = None,
     namespace: Optional[str] = None,
     name: Optional[str] = None,
+    status: Optional[schema.BuildStatus] = None,
+    packages: Optional[List[str]] = Query([]),
     conda_store=Depends(dependencies.get_conda_store),
     auth=Depends(dependencies.get_auth),
     entity=Depends(dependencies.get_entity),
@@ -267,6 +269,8 @@ def api_list_environments(
             search=search,
             namespace=namespace,
             name=name,
+            status=status,
+            packages=packages,
             show_soft_deleted=False,
         ),
     )
@@ -443,13 +447,18 @@ def api_post_specification(
 
 @router_api.get("/build/", response_model=schema.APIListBuild)
 def api_list_builds(
+    status: Optional[schema.BuildStatus] = None,
+    packages: Optional[List[str]] = Query([]),
     conda_store=Depends(dependencies.get_conda_store),
     auth=Depends(dependencies.get_auth),
     entity=Depends(dependencies.get_entity),
     paginated_args=Depends(get_paginated_args),
 ):
     orm_builds = auth.filter_builds(
-        entity, api.list_builds(conda_store.db, show_soft_deleted=True)
+        entity,
+        api.list_builds(
+            conda_store.db, status=status, packages=packages, show_soft_deleted=True
+        ),
     )
     return paginated_api_response(
         orm_builds,


### PR DESCRIPTION
Adds the ability to filter builds and environments on:
 - packages in the environment
 - status of the build
 - artfacts that exist for given build

This is critical for nb_conda_store_kernels being able to efficiently filter out given environments that are ready to run. Additionally qhub needs this for dask_gateway and cdsdashboards extensions.