### PR TITLE
Adding token endpoint along with tests

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -40,6 +40,9 @@ jobs:
         run: |
           python -m build --sdist
           twine check dist/*
+      - name: Unit Tests
+        run: |
+          pytest
       - name: Deploy docker-compose
         run: |
           docker-compose up -d

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -133,6 +133,7 @@ jobs:
           export CONDA_STORE_URL=http://localhost:5000/conda-store
           export CONDA_STORE_AUTH=none
           conda-store info
+          conda-store token
           conda-store list namespace
           conda-store list build
           conda-store list environment
@@ -145,6 +146,7 @@ jobs:
           export CONDA_STORE_PASSWORD=password
 
           conda-store info
+          conda-store token
           conda-store list build
           echo "waiting for build 1 to finish"
           conda-store wait 1

--- a/conda-store-server/conda_store_server/environment.py
+++ b/conda-store-server/conda_store_server/environment.py
@@ -3,8 +3,6 @@ from typing import List
 
 import yaml
 import pydantic
-from conda.models.match_spec import MatchSpec
-from pkg_resources import Requirement
 
 from conda_store_server import schema, conda
 
@@ -71,6 +69,8 @@ def validate_environment_conda_packages(
     required_packages: List[str],
 ) -> schema.Specification:
     def _package_names(dependencies):
+        from conda.models.match_spec import MatchSpec
+
         return {MatchSpec(_).name: _ for _ in dependencies if isinstance(_, str)}
 
     if len(specification.dependencies) == 0:
@@ -101,6 +101,8 @@ def validate_environment_pypi_packages(
     required_packages: List[str],
 ) -> schema.Specification:
     def _package_names(packages):
+        from pkg_resources import Requirement
+
         result = {}
         for p in packages:
             if isinstance(p, str):

--- a/conda-store-server/conda_store_server/schema.py
+++ b/conda-store-server/conda_store_server/schema.py
@@ -339,8 +339,10 @@ class APIGetStatus(APIResponse):
 # GET /api/v1/permission
 class APIGetPermissionData(BaseModel):
     authenticated: bool
-    entity_permissions: Dict[str, List[str]]
     primary_namespace: str
+    entity_permissions: Dict[str, List[str]]
+    entity_roles: Dict[str, List[str]]
+    expiration: Optional[datetime.datetime]
 
 
 class APIGetPermission(APIResponse):

--- a/conda-store-server/conda_store_server/schema.py
+++ b/conda-store-server/conda_store_server/schema.py
@@ -346,6 +346,15 @@ class APIGetPermission(APIResponse):
     data: APIGetPermissionData
 
 
+# POST /api/v1/token
+class APIPostTokenData(BaseModel):
+    token: str
+
+
+class APIPostToken(APIResponse):
+    data: APIPostTokenData
+
+
 # GET /api/v1/namespace
 class APIListNamespace(APIPaginatedResponse):
     data: List[Namespace]

--- a/conda-store-server/conda_store_server/server/auth.py
+++ b/conda-store-server/conda_store_server/server/auth.py
@@ -152,7 +152,9 @@ class RBACAuthorizationBackend(LoggingConfigurable):
                 permissions = permissions | set(entity_permissions)
         return permissions
 
-    def is_subset_entity_permissions(self, entity_bindings, new_entiy_bindings, authenticated=False):
+    def is_subset_entity_permissions(
+        self, entity_bindings, new_entiy_bindings, authenticated=False
+    ):
         pass
 
     def authorize(

--- a/conda-store-server/conda_store_server/server/auth.py
+++ b/conda-store-server/conda_store_server/server/auth.py
@@ -15,9 +15,7 @@ from conda_store_server import schema, orm
 from conda_store_server.server import dependencies
 
 
-ARN_ALLOWED_REGEX = re.compile(
-    f"^([{schema.ALLOWED_CHARACTERS}*]+)/([{schema.ALLOWED_CHARACTERS}*]+)$"
-)
+ARN_ALLOWED_REGEX = re.compile(schema.ARN_ALLOWED)
 
 
 class AuthenticationBackend(LoggingConfigurable):
@@ -91,7 +89,7 @@ class RBACAuthorizationBackend(LoggingConfigurable):
     )
 
     @staticmethod
-    def compile_arn_regex(arn):
+    def compile_arn_regex(arn: str) -> re.Pattern:
         """Take an arn of form "example-*/example-*" and compile to regular expression
 
         The expression "example-*/example-*" will match:
@@ -108,14 +106,37 @@ class RBACAuthorizationBackend(LoggingConfigurable):
         return re.compile(regex_arn)
 
     @staticmethod
-    def compile_arn_sql_like(arn):
+    def compile_arn_sql_like(arn: str) -> str:
         match = ARN_ALLOWED_REGEX.match(arn)
         if match is None:
             raise ValueError(f"invalid arn={arn}")
 
         return re.sub(r"\*", "%", match.group(1)), re.sub(r"\*", "%", match.group(2))
 
-    def get_entity_bindings(self, entity_bindings, authenticated=False):
+    @staticmethod
+    def is_arn_subset(arn_1: str, arn_2: str):
+        """Return true if arn_1 is a subset of arn_2
+
+        Conda-Store allows flexible arn statements such as "a*b*/c*"
+        with "*" being a wildcard seen in regexes. This makes the
+        calculation of if a arn is a subset of another non
+        trivial. This codes solves this problem.
+        """
+        arn_1_matches_arn_2 = (
+            re.fullmatch(
+                re.sub(r"\*", f"[{schema.ALLOWED_CHARACTERS}*]*", arn_1), arn_2
+            )
+            is not None
+        )
+        arn_2_matches_arn_1 = (
+            re.fullmatch(
+                re.sub(r"\*", f"[{schema.ALLOWED_CHARACTERS}*]*", arn_2), arn_1
+            )
+            is not None
+        )
+        return (arn_1_matches_arn_2 and arn_2_matches_arn_1) or arn_2_matches_arn_1
+
+    def get_entity_bindings(self, entity_bindings, authenticated: bool = False):
         if authenticated:
             return {
                 **self.authenticated_role_bindings,
@@ -133,7 +154,9 @@ class RBACAuthorizationBackend(LoggingConfigurable):
             permissions = permissions | self.role_mappings[role]
         return permissions
 
-    def get_entity_binding_permissions(self, entity_bindings, authenticated=False):
+    def get_entity_binding_permissions(
+        self, entity_bindings, authenticated: bool = False
+    ):
         entity_bindings = self.get_entity_bindings(
             entity_bindings=entity_bindings, authenticated=authenticated
         )
@@ -142,7 +165,17 @@ class RBACAuthorizationBackend(LoggingConfigurable):
             for entity_arn, entity_roles in entity_bindings.items()
         }
 
-    def get_entity_permissions(self, entity_bindings, arn, authenticated=False):
+    def get_entity_permissions(
+        self, entity_bindings, arn: str, authenticated: bool = False
+    ):
+        """Get set of permissions for given ARN given AUTHENTICATION
+        state and entity_bindings
+
+        ARN is a specific "<namespace>/<name>"
+        AUTHENTICATION is either True/False
+        ENTITY_BINDINGS is a mapping of ARN with regex support to ROLES
+        ROLES is a set of roles defined in `RBACAuthorizationBackend.role_mappings`
+        """
         entity_binding_permissions = self.get_entity_binding_permissions(
             entity_bindings=entity_bindings, authenticated=authenticated
         )
@@ -153,9 +186,32 @@ class RBACAuthorizationBackend(LoggingConfigurable):
         return permissions
 
     def is_subset_entity_permissions(
-        self, entity_bindings, new_entiy_bindings, authenticated=False
+        self, entity_bindings, new_entity_bindings, authenticated=False
     ):
-        pass
+        """Determine if new_entity_bindings is a strict subset of entity_bindings
+
+        This feature is required to allow authenticated entitys to
+        create new permissions that are a strict subset of its
+        permissions.
+        """
+        entity_binding_permissions = self.get_entity_binding_permissions(
+            entity_bindings=entity_bindings, authenticated=authenticated
+        )
+        new_entity_binding_permissions = self.get_entity_binding_permissions(
+            entity_bindings=new_entity_bindings, authenticated=authenticated
+        )
+        for (
+            new_entity_binding,
+            new_permissions,
+        ) in new_entity_binding_permissions.items():
+            _permissions = set()
+            for entity_binding, permissions in entity_binding_permissions.items():
+                if self.is_arn_subset(new_entity_binding, entity_binding):
+                    _permissions = _permissions | permissions
+
+            if not new_permissions <= _permissions:
+                return False
+        return True
 
     def authorize(
         self, entity_bindings, arn, required_permissions, authenticated=False

--- a/conda-store-server/conda_store_server/server/auth.py
+++ b/conda-store-server/conda_store_server/server/auth.py
@@ -152,6 +152,9 @@ class RBACAuthorizationBackend(LoggingConfigurable):
                 permissions = permissions | set(entity_permissions)
         return permissions
 
+    def is_subset_entity_permissions(self, entity_bindings, new_entiy_bindings, authenticated=False):
+        pass
+
     def authorize(
         self, entity_bindings, arn, required_permissions, authenticated=False
     ):

--- a/conda-store-server/conda_store_server/server/views/api.py
+++ b/conda-store-server/conda_store_server/server/views/api.py
@@ -169,7 +169,9 @@ def api_post_token(
     entity_binding_permissions = auth.authorization.get_entity_bindings(
         entity.role_bindings if authenticated else {}, authenticated=authenticated
     )
-    primary_namespace = conda_store.default_namespace if not authenticated else entity.primary_namespace
+    primary_namespace = (
+        conda_store.default_namespace if not authenticated else entity.primary_namespace
+    )
 
     token = schema.AuthenticationToken(
         primary_namespace=primary_namespace,
@@ -179,7 +181,6 @@ def api_post_token(
         "status": "ok",
         "data": {"token": auth.authentication.encrypt_token(token)},
     }
-
 
 
 @router_api.get(

--- a/conda-store-server/tests/test_auth.py
+++ b/conda-store-server/tests/test_auth.py
@@ -23,7 +23,10 @@ def test_compile_arn_regex(expression, resource, match):
 
 @pytest.mark.parametrize(
     "expression, namespace, name",
-    [("e*/d*", "e%", "d%"), ("*e*d*/*e", "%e%d%", "%e"), ],
+    [
+        ("e*/d*", "e%", "d%"),
+        ("*e*d*/*e", "%e%d%", "%e"),
+    ],
 )
 def test_compile_arn_sql_like(expression, namespace, name):
     result = RBACAuthorizationBackend.compile_arn_sql_like(expression)
@@ -31,7 +34,11 @@ def test_compile_arn_sql_like(expression, namespace, name):
 
 
 @pytest.mark.parametrize(
-    "token_string,authenticated", [("", False), ("asdf", False), ],
+    "token_string,authenticated",
+    [
+        ("", False),
+        ("asdf", False),
+    ],
 )
 def test_authenticated(token_string, authenticated):
     authentication = AuthenticationBackend()
@@ -46,7 +53,10 @@ def test_valid_token():
     token = authentication.encrypt_token(
         AuthenticationToken(
             primary_namespace="default",
-            role_bindings={"default/*": ["viewer"], "e*/e*": ["admin"], },
+            role_bindings={
+                "default/*": ["viewer"],
+                "e*/e*": ["admin"],
+            },
         )
     )
 
@@ -62,7 +72,10 @@ def test_expired_token():
         AuthenticationToken(
             primary_namespace="default",
             exp=datetime.datetime.utcnow() - datetime.timedelta(hours=1),
-            role_bindings={"default/*": ["viewer"], "e*/e*": ["admin"], },
+            role_bindings={
+                "default/*": ["viewer"],
+                "e*/e*": ["admin"],
+            },
         )
     )
 
@@ -73,31 +86,41 @@ def test_expired_token():
     "entity_bindings,arn,permissions,authorized",
     [
         (
-            {"example-namespace/example-name": {"developer"}, },
+            {
+                "example-namespace/example-name": {"developer"},
+            },
             "example-namespace/example-name",
             {Permissions.ENVIRONMENT_CREATE},
             True,
         ),
         (
-            {"example-namespace/example-name": {"developer", "viewer"}, },
+            {
+                "example-namespace/example-name": {"developer", "viewer"},
+            },
             "example-namespace/example-name",
             {Permissions.ENVIRONMENT_DELETE},
             False,
         ),
         (
-            {"example-namespace/example-name": {"developer", "admin"}, },
+            {
+                "example-namespace/example-name": {"developer", "admin"},
+            },
             "example-namespace/example-name",
             {Permissions.ENVIRONMENT_DELETE},
             True,
         ),
         (
-            {"e*/e*am*": {"admin"}, },
+            {
+                "e*/e*am*": {"admin"},
+            },
             "example-namespace/example-name",
             {Permissions.ENVIRONMENT_CREATE},
             True,
         ),
         (
-            {"e*/e*am*": {"viewer"}, },
+            {
+                "e*/e*am*": {"viewer"},
+            },
             "example-namespace/example-name",
             {Permissions.ENVIRONMENT_CREATE},
             False,
@@ -116,7 +139,10 @@ def test_end_to_end_auth_flow():
     token = authentication.encrypt_token(
         AuthenticationToken(
             primary_namespace="default",
-            role_bindings={"default/*": ["viewer"], "e*/e*": ["admin"], },
+            role_bindings={
+                "default/*": ["viewer"],
+                "e*/e*": ["admin"],
+            },
         )
     )
 
@@ -126,6 +152,9 @@ def test_end_to_end_auth_flow():
     assert authorization.authorize(
         token_model.role_bindings,
         "example-namespace/example-name",
-        {Permissions.ENVIRONMENT_DELETE, Permissions.ENVIRONMENT_READ, },
+        {
+            Permissions.ENVIRONMENT_DELETE,
+            Permissions.ENVIRONMENT_READ,
+        },
         authenticated=True,
     )

--- a/conda-store-server/tests/test_auth.py
+++ b/conda-store-server/tests/test_auth.py
@@ -4,9 +4,8 @@ import datetime
 from conda_store_server.server.auth import (
     AuthenticationBackend,
     RBACAuthorizationBackend,
-    Permissions,
 )
-from conda_store_server.schema import AuthenticationToken
+from conda_store_server.schema import AuthenticationToken, Permissions
 
 
 @pytest.mark.parametrize(
@@ -81,6 +80,12 @@ def test_expired_token():
         ),
         (
             {"example-namespace/example-name": {"developer", "viewer"}, },
+            "example-namespace/example-name",
+            {Permissions.ENVIRONMENT_DELETE},
+            False,
+        ),
+        (
+            {"example-namespace/example-name": {"developer", "admin"}, },
             "example-namespace/example-name",
             {Permissions.ENVIRONMENT_DELETE},
             True,

--- a/conda-store-server/tests/test_auth.py
+++ b/conda-store-server/tests/test_auth.py
@@ -158,3 +158,55 @@ def test_end_to_end_auth_flow():
         },
         authenticated=True,
     )
+
+
+@pytest.mark.parametrize("arn_1,arn_2,value", [
+    ("ab/cd", "a*b/c*d", True),
+    ("a1111b/c22222d", "a*b/c*d", True),
+    ("a1/cd", "a*b/c*d", False),
+    ("abc/ed", "a*b*c/e*d", True),
+    ("a111bc/ed", "a*b*c/e*d", True),
+    ("a111b2222c/e3333d", "a*b*c/e*d", True),
+    ("aaabbbcccc/eeddd", "a*b*c/e*d", True),
+    ("aaabbbcccc1/eeddd", "a*b*c/e*d", False),
+    ("aaabbbcccc1c/eeddd", "a*b*c/e*d", True),
+])
+def test_is_arn_subset(arn_1, arn_2, value):
+    assert RBACAuthorizationBackend.is_arn_subset(arn_1, arn_2) == value
+
+
+@pytest.mark.parametrize("entity_bindings, new_entity_bindings, authenticated, value", [
+    # */* viewer is a subset of admin
+    ({"*/*": ["admin"]}, {"*/*": ["viewer"]}, False, True),
+    ({"*/*": ["admin"]}, {"*/*": ["viewer"]}, True, True),
+    # */* admin is not a subset of viewer
+    ({"*/*": ["viewer"]}, {"*/*": ["admin"]}, False, False),
+    ({"*/*": ["viewer"]}, {"*/*": ["admin"]}, True, False),
+    # a/b viewer is a subset of admin
+    ({"a/b": ["admin"]}, {"a/b": ["viewer"]}, False, True),
+    ({"a/b": ["admin"]}, {"a/b": ["viewer"]}, True, True),
+    # a/b admin is not a subset of viewer
+    ({"a/b": ["viewer"]}, {"a/b": ["admin"]}, False, False),
+    ({"a/b": ["viewer"]}, {"a/b": ["admin"]}, True, False),
+    # default/* vs. */*
+    ({"*/*": ["viewer"]}, {"default/*": ["viewer"]}, False, True),
+    ({"*/*": ["viewer"]}, {"default/*": ["viewer"]}, True, True),
+    # efault/* vs. d*/*
+    ({"d*/*": ["viewer"]}, {"efault/*": ["viewer"]}, False, False),
+    ({"d*/*": ["viewer"]}, {"efault/*": ["viewer"]}, True, False),
+    # multiple entities keys
+    ({"d*/*": ["viewer"], "de*/*": ["admin"]}, {"default/*": ["developer"]}, False, True),
+    ({"d*/*": ["viewer"], "de*/*": ["admin"]}, {"default/*": ["developer"]}, True, True),
+    # multiple entities keys
+    ({"d*/*": ["viewer"], "de*/*": ["admin"]}, {"dcefault/*": ["developer"]}, False, False),
+    ({"d*/*": ["viewer"], "de*/*": ["admin"]}, {"dcefault/*": ["developer"]}, True, False),
+    # multiple entities keys
+    ({"d*/*": ["viewer"]}, {"d*/*": ["viewer"], "dc*/*": ["viewer"]}, False, True),
+    ({"d*/*": ["viewer"]}, {"d*/*": ["viewer"], "dc*/*": ["viewer"]}, True, True),
+    # multiple entities keys
+    ({"d*/*": ["viewer"]}, {"d*/*": ["viewer"], "dc*/*": ["developer"]}, False, False),
+    ({"d*/*": ["viewer"]}, {"d*/*": ["viewer"], "dc*/*": ["developer"]}, True, False),
+])
+def test_is_subset_entity_permissions(entity_bindings, new_entity_bindings, authenticated, value):
+    authorization = RBACAuthorizationBackend()
+    assert authorization.is_subset_entity_permissions(entity_bindings, new_entity_bindings, authenticated) == value

--- a/conda-store/conda_store/api.py
+++ b/conda-store/conda_store/api.py
@@ -66,6 +66,10 @@ class CondaStoreAPI:
         async with self.session.get(self.api_url / "permission") as response:
             return (await response.json())["data"]
 
+    async def create_token(self):
+        async with self.session.post(self.api_url / "token") as response:
+            return (await response.json())["data"]["token"]
+
     async def list_namespaces(self):
         return await self.get_paginated_request(self.api_url / "namespace")
 

--- a/conda-store/conda_store/cli.py
+++ b/conda-store/conda_store/cli.py
@@ -417,3 +417,11 @@ async def list_environment(
         )
     elif output == "json":
         utils.output_json(builds)
+
+
+@cli.command()
+@click.pass_context
+@utils.coro
+async def token(ctx):
+    async with ctx.obj["CONDA_STORE_API"] as conda_store:
+        print(await conda_store.create_token(), end="")

--- a/flake.nix
+++ b/flake.nix
@@ -20,6 +20,7 @@
           pkgs.k9s
           pkgs.docker-compose
 
+          # conda-store-server
           pythonPackages.yarl
           pythonPackages.requests
           pythonPackages.pydantic
@@ -31,12 +32,15 @@
           pythonPackages.pyjwt
           pythonPackages.minio
           pythonPackages.filelock
+          pythonPackages.sqlalchemy
 
+          # conda-store
           pythonPackages.rich
           pythonPackages.click
           pythonPackages.aiohttp
           pythonPackages.ruamel-yaml
 
+          # dev
           pythonPackages.pytest
           pythonPackages.black
           pythonPackages.flake8


### PR DESCRIPTION
This is a necessary feature for integrating Conda-Store into CDSDashboards and Dask-Gateway. I need some way of provisioning tokens with smaller credentials.

Closes #331 