### PR TITLE
fix 351 : sort builds by start/scheduled/end dt

### DIFF
--- a/conda-store-server/conda_store_server/server/views/api.py
+++ b/conda-store-server/conda_store_server/server/views/api.py
@@ -545,6 +545,9 @@ def api_list_builds(
         exclude={"specification", "packages", "build_artifacts"},
         allowed_sort_bys={
             "id": orm.Build.id,
+            "started_on":orm.Build.started_on,
+            "scheduled_on":orm.Build.scheduled_on,
+            "ended_on":orm.Build.ended_on
         },
         default_sort_by=["id"],
     )

--- a/conda-store-server/conda_store_server/server/views/api.py
+++ b/conda-store-server/conda_store_server/server/views/api.py
@@ -545,9 +545,9 @@ def api_list_builds(
         exclude={"specification", "packages", "build_artifacts"},
         allowed_sort_bys={
             "id": orm.Build.id,
-            "started_on":orm.Build.started_on,
-            "scheduled_on":orm.Build.scheduled_on,
-            "ended_on":orm.Build.ended_on
+            "started_on": orm.Build.started_on,
+            "scheduled_on": orm.Build.scheduled_on,
+            "ended_on": orm.Build.ended_on,
         },
         default_sort_by=["id"],
     )


### PR DESCRIPTION
Fixes #351 : allows sorting builds by `started_on`, `scheduled_on` or `ended_on`