### PR TITLE
add repo.anaconda.com to default

### DIFF
--- a/conda-store-server/conda_store_server/app.py
+++ b/conda-store-server/conda_store_server/app.py
@@ -101,6 +101,7 @@ class CondaStore(LoggingConfigurable):
         [
             "main",
             "conda-forge",
+            "https://repo.anaconda.com/pkgs/main",
         ],
         help="Allowed conda channels to be used in conda environments",
         config=True,


### PR DESCRIPTION
 * as noted by @costrouc after an environment build failure,
   add a new channel URL that is used by some conda-forge packages
   to conda_allowed_channels