### PR TITLE
Fix auth when header is passed

### DIFF
--- a/conda-store-server/conda_store_server/server/auth.py
+++ b/conda-store-server/conda_store_server/server/auth.py
@@ -394,7 +394,7 @@ form.addEventListener('submit', loginHandler);
             request.state.entity = self.authentication.authenticate(token)
         elif request.headers.get("Authorization"):
             # auth bearer based authentication
-            token = request.headers.get("Authorization").split(" ")[1]
+            token = request.headers.get("Authorization")
             request.state.entity = self.authentication.authenticate(token)
         else:
             request.state.entity = None


### PR DESCRIPTION
Working on the UI, we pass the authorization header this way : 
```react
headers.set(
      "Authorization",   "eyJ0e...TOKEN_HERE_...J9s"
    );
```

Which result in a GET query like : 
```
GET /conda-store/api/v1/ HTTP/1.1
Accept: */*
Accept-Encoding: gzip, deflate, br
Accept-Language: fr-FR,fr;q=0.9,en-US;q=0.8,en;q=0.7
Connection: keep-alive
Host: 127.0.0.1:5000
Origin: http://127.0.0.1
Referer: http://127.0.0.1/
Sec-Fetch-Dest: empty
Sec-Fetch-Mode: cors
Sec-Fetch-Site: same-site
User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/103.0.0.0 Safari/537.36
authorization: eyJ0e...TOKEN_HERE_...J9s
sec-ch-ua: ".Not/A)Brand";v="99", "Google Chrome";v="103", "Chromium";v="103"
sec-ch-ua-mobile: ?0
sec-ch-ua-platform: "macOS"
```


In `auth.py`, the auth token is retrieved directly by `request.headers.get("Authorization")` and doesn't require a split on space.

This fixes the issues we experience with accessing the API from the UI.
