### PR TITLE
Fix CORSMiddleware to accept headers

### DIFF
--- a/conda-store-server/conda_store_server/server/app.py
+++ b/conda-store-server/conda_store_server/server/app.py
@@ -160,6 +160,7 @@ class CondaStoreServer(Application):
             CORSMiddleware,
             allow_origins=["*"],
             allow_credentials=True,
+            allow_headers=["*"],
         )
         app.add_middleware(
             SessionMiddleware, secret_key=self.authentication.authentication.secret


### PR DESCRIPTION
This fix is necessary for the UI to access the API.

Without this fix, the API returns `403` whatever we do. 