### PR TITLE
Fix when updating an env

### DIFF
--- a/conda-store-server/conda_store_server/app.py
+++ b/conda-store-server/conda_store_server/app.py
@@ -451,7 +451,7 @@ class CondaStore(LoggingConfigurable):
             self.db.add(environment)
             self.db.commit()
         else:
-            environment.description = specification.description
+            environment.description = specification.spec["description"]
             self.db.commit()
 
         build = self.create_build(environment.id, specification.sha256)


### PR DESCRIPTION
I noticed a bug when updating an env from the UI, i.e. using the `POST /conda-store/api/v1/specification/` endpoint. 

I plead guilty :)