### PR TITLE
Fix CORS on login endpoint

### DIFF
--- a/conda-store-server/conda_store_server/server/app.py
+++ b/conda-store-server/conda_store_server/server/app.py
@@ -161,7 +161,7 @@ class CondaStoreServer(Application):
             allow_origins=["*"],
             allow_credentials=True,
             allow_headers=["*"],
-            allow_methods=["*"]
+            allow_methods=["*"],
         )
         app.add_middleware(
             SessionMiddleware, secret_key=self.authentication.authentication.secret

--- a/conda-store-server/conda_store_server/server/app.py
+++ b/conda-store-server/conda_store_server/server/app.py
@@ -161,6 +161,7 @@ class CondaStoreServer(Application):
             allow_origins=["*"],
             allow_credentials=True,
             allow_headers=["*"],
+            allow_methods=["*"]
         )
         app.add_middleware(
             SessionMiddleware, secret_key=self.authentication.authentication.secret


### PR DESCRIPTION
CORS appeared again, this time using the `login` endpoint. It appears we need to let the CORSMiddleware be flexible on the methods it accepts.