### PR TITLE
return description in get api/v1/environment/

### DIFF
--- a/conda-store-server/conda_store_server/schema.py
+++ b/conda-store-server/conda_store_server/schema.py
@@ -146,6 +146,8 @@ class Environment(BaseModel):
     current_build_id: int
     current_build: Optional[Build]
 
+    description: str
+
     class Config:
         orm_mode = True
 


### PR DESCRIPTION
I realize I forgot to return the env description in GET api/v1/environment/{namespace}/{environment_name}