### PR TITLE
env description is optional

### DIFF
--- a/conda-store-server/conda_store_server/schema.py
+++ b/conda-store-server/conda_store_server/schema.py
@@ -146,7 +146,7 @@ class Environment(BaseModel):
     current_build_id: int
     current_build: Optional[Build]
 
-    description: str
+    description: Optional[str]
 
     class Config:
         orm_mode = True


### PR DESCRIPTION
I forgot to put the description of env as optional in the ORM schema, leading to validation errors when requesting the API.

This fix is important for the UI to work.