### PR TITLE
Removing unsupported `--debug` flag from `uvicorn.run`

### DIFF
--- a/conda-store-server/conda_store_server/server/app.py
+++ b/conda-store-server/conda_store_server/server/app.py
@@ -304,7 +304,6 @@ class CondaStoreServer(Application):
                 host=self.address,
                 port=self.port,
                 reload=False,
-                debug=(self.log_level == logging.DEBUG),
                 workers=1,
                 proxy_headers=self.behind_proxy,
                 forwarded_allow_ips=("*" if self.behind_proxy else None),


### PR DESCRIPTION
closes #395 

This is a very simple fix to make sure we can still run `uvicorn` without pinning it in main. We should rethink the debug mode strategy for the main app if there is a need for it... or pin uvicorn to '<0.19.0'