### PR TITLE
Fix #439 : conda indexed channels

### DIFF
--- a/conda-store-server/conda_store_server/app.py
+++ b/conda-store-server/conda_store_server/app.py
@@ -125,10 +125,7 @@ class CondaStore(LoggingConfigurable):
     )
 
     conda_indexed_channels = List(
-        [
-            "main",
-            "conda-forge",
-        ],
+        ["main", "conda-forge", "https://repo.anaconda.com/pkgs/main"],
         help="Conda channels to be indexed by conda-store at start.  Defaults to main and conda-forge.",
         config=True,
     )

--- a/conda-store-server/conda_store_server/app.py
+++ b/conda-store-server/conda_store_server/app.py
@@ -32,7 +32,7 @@ from conda_store_server import (
 def conda_store_validate_specification(
     conda_store: "CondaStore", namespace: str, specification: schema.CondaSpecification
 ) -> schema.CondaSpecification:
-    
+
     specification = environment.validate_environment_channels(
         specification,
         conda_store.conda_channel_alias,
@@ -132,7 +132,6 @@ class CondaStore(LoggingConfigurable):
         help="Conda channels to be indexed by conda-store at start.  Defaults to main and conda-forge.",
         config=True,
     )
-
 
     conda_default_packages = List(
         [],
@@ -404,7 +403,7 @@ class CondaStore(LoggingConfigurable):
     def ensure_conda_channels(self):
         """Ensure that conda-store indexed channels and packages are in database"""
         self.log.info("updating conda store channels")
-        
+
         for channel in self.conda_indexed_channels:
             normalized_channel = conda.normalize_channel_name(
                 self.conda_channel_alias, channel

--- a/conda-store-server/conda_store_server/app.py
+++ b/conda-store-server/conda_store_server/app.py
@@ -32,6 +32,7 @@ from conda_store_server import (
 def conda_store_validate_specification(
     conda_store: "CondaStore", namespace: str, specification: schema.CondaSpecification
 ) -> schema.CondaSpecification:
+    
     specification = environment.validate_environment_channels(
         specification,
         conda_store.conda_channel_alias,
@@ -122,6 +123,16 @@ class CondaStore(LoggingConfigurable):
         help="Allowed conda channels to be used in conda environments. If set to empty list all channels are accepted. Defaults to main and conda-forge",
         config=True,
     )
+
+    conda_indexed_channels = List(
+        [
+            "main",
+            "conda-forge",
+        ],
+        help="Conda channels to be indexed by conda-store at start.  Defaults to main and conda-forge.",
+        config=True,
+    )
+
 
     conda_default_packages = List(
         [],
@@ -391,10 +402,10 @@ class CondaStore(LoggingConfigurable):
         os.makedirs(self.store_directory, exist_ok=True)
 
     def ensure_conda_channels(self):
-        """Ensure that conda-store allowed channels and packages are in database"""
+        """Ensure that conda-store indexed channels and packages are in database"""
         self.log.info("updating conda store channels")
-
-        for channel in self.conda_allowed_channels:
+        
+        for channel in self.conda_indexed_channels:
             normalized_channel = conda.normalize_channel_name(
                 self.conda_channel_alias, channel
             )

--- a/conda-store-server/conda_store_server/build.py
+++ b/conda-store-server/conda_store_server/build.py
@@ -65,6 +65,7 @@ def set_build_completed(conda_store, build, logs, packages):
 
         channel_orm = api.get_conda_channel(conda_store.db, channel)
         if channel_orm is None:
+            # Empty list for conda_allowed_channels allows any channel ( PR #358 )
             if len(conda_store.conda_allowed_channels) == 0:
                 channel_orm = api.create_conda_channel(conda_store.db, channel)
                 conda_store.db.commit()
@@ -284,6 +285,7 @@ def solve_conda_environment(conda_store, solve):
 
             channel_orm = api.get_conda_channel(conda_store.db, channel)
             if channel_orm is None:
+                # Empty list for conda_allowed_channels allows any channel ( PR #358 )
                 if len(conda_store.conda_allowed_channels) == 0:
                     channel_orm = api.create_conda_channel(conda_store.db, channel)
                     conda_store.db.commit()

--- a/docs/administration.md
+++ b/docs/administration.md
@@ -121,6 +121,10 @@ the channel `repodata` and `channeldata` from. The default is `main`
 and `conda-forge`. If `conda_allowed_channels` is an empty list all
 Channels are accepted by users.
 
+`CondaStore.conda_indexed_channels` tells conda-store which channels to prefetch
+the channel `repodata` and `channeldata` from. The default is `main`
+and `conda-forge`.
+
 `CondaStore.conda_default_packages` is a list of Conda packages that
 are included by default if none are specified within the specification
 dependencies.


### PR DESCRIPTION
This PR fixes issue #439 

The default indexed channels are `main` and `conda-forge`.

The issue suggested the name `conda_indexed_channels`. For clarity, I'd suggest to rename it as `conda_prefetched_channels` or something similar. 
The name `conda_indexed_channels` confused me at first, because "indexed channels" means to me "channels already indexed", and not "channels to index".