### PR TITLE
Function for system validation of conda-store actions

### DIFF
--- a/conda-store-server/conda_store_server/api.py
+++ b/conda-store-server/conda_store_server/api.py
@@ -314,3 +314,22 @@ def get_metrics(db):
 
     metrics["environments"] = db.query(orm.Environment).count()
     return metrics
+
+
+def get_system_metrics(db):
+    return db.query(
+        orm.CondaStoreConfiguration.free_storage.label("disk_free"),
+        orm.CondaStoreConfiguration.total_storage.label("disk_total"),
+        orm.CondaStoreConfiguration.disk_usage,
+    ).first()
+
+
+def get_namespace_metrics(db):
+    return db.query(
+        orm.Namespace.name,
+        func.count(orm.Environment.id),
+        func.count(orm.Build.id),
+        func.sum(orm.Build.size)
+    ).join(orm.Build.environment) \
+     .join(orm.Environment.namespace) \
+     .group_by(orm.Namespace.name)

--- a/conda-store-server/conda_store_server/api.py
+++ b/conda-store-server/conda_store_server/api.py
@@ -1,7 +1,7 @@
 from typing import List
 import re
 
-from sqlalchemy import func, null, or_
+from sqlalchemy import func, null, or_, distinct
 
 from conda_store_server import orm, schema
 from conda_store_server.conda import conda_platform
@@ -325,11 +325,14 @@ def get_system_metrics(db):
 
 
 def get_namespace_metrics(db):
-    return db.query(
-        orm.Namespace.name,
-        func.count(orm.Environment.id),
-        func.count(orm.Build.id),
-        func.sum(orm.Build.size)
-    ).join(orm.Build.environment) \
-     .join(orm.Environment.namespace) \
-     .group_by(orm.Namespace.name)
+    return (
+        db.query(
+            orm.Namespace.name,
+            func.count(distinct(orm.Environment.id)),
+            func.count(distinct(orm.Build.id)),
+            func.sum(orm.Build.size),
+        )
+        .join(orm.Build.environment)
+        .join(orm.Environment.namespace)
+        .group_by(orm.Namespace.name)
+    )

--- a/conda-store-server/conda_store_server/app.py
+++ b/conda-store-server/conda_store_server/app.py
@@ -32,7 +32,6 @@ from conda_store_server import (
 def conda_store_validate_specification(
     conda_store: "CondaStore", namespace: str, specification: schema.CondaSpecification
 ) -> schema.CondaSpecification:
-
     specification = environment.validate_environment_channels(
         specification,
         conda_store.conda_channel_alias,
@@ -55,6 +54,22 @@ def conda_store_validate_specification(
     )
 
     return specification
+
+
+def conda_store_validate_action(
+    conda_store: "CondaStore",
+    namespace: str,
+    action: schema.Permissions,
+) -> None:
+    system_metrics = api.get_system_metrics(conda_store.db)
+
+    if action in (
+        schema.Permissions.ENVIRONMENT_CREATE,
+        schema.Permissions.ENVIRONMENT_UPDATE,
+    ) and (conda_store.storage_threshold > system_metrics.disk_free):
+        raise utils.CondaStoreError(
+            f"`CondaStore.storage_threshold` reached. Action {action.value} prevented due to insufficient storage space"
+        )
 
 
 class CondaStore(LoggingConfigurable):
@@ -169,6 +184,12 @@ class CondaStore(LoggingConfigurable):
     conda_max_solve_time = Integer(
         5 * 60,  # 5 minute
         help="Maximum time in seconds to allow for solving a given conda environment",
+        config=True,
+    )
+
+    storage_threshold = Integer(
+        5 * 1024**3,  # 5 GB
+        help="Storage threshold of available storage to prevent conda-store builds in bytes",
         config=True,
     )
 
@@ -300,7 +321,13 @@ class CondaStore(LoggingConfigurable):
 
     validate_specification = Callable(
         conda_store_validate_specification,
-        help="callable function taking conda_store and specification as input arguments to apply for validating and modifying a given specification. If there are validation issues with the environment ValueError with message should be raised. If changed you may need to call the default function to preseve many of the trait effects e.g. `c.CondaStore.default_channels` etc",
+        help="callable function taking conda_store, namespace, and specification as input arguments to apply for validating and modifying a given specification. If there are validation issues with the environment ValueError with message should be raised. If changed you may need to call the default function to preseve many of the trait effects e.g. `c.CondaStore.default_channels` etc",
+        config=True,
+    )
+
+    validate_action = Callable(
+        conda_store_validate_action,
+        help="callable function taking conda_store, namespace, and action. If there are issues with performing the given action raise a CondaStoreError should be raised.",
         config=True,
     )
 
@@ -422,6 +449,12 @@ class CondaStore(LoggingConfigurable):
                 self.db.commit()
 
     def register_solve(self, specification: schema.CondaSpecification):
+        """Registers a solve for a given specification"""
+        self.validate_action(
+            conda_store=self,
+            namespace="solve",
+            action=schema.Permissions.ENVIRONMENT_SOLVE,
+        )
         specification_model = self.validate_specification(
             conda_store=self,
             namespace="solve",
@@ -473,6 +506,11 @@ class CondaStore(LoggingConfigurable):
         else:
             namespace = namespace_model
 
+        self.validate_action(
+            conda_store=self,
+            namespace=namespace.name,
+            action=schema.Permissions.ENVIRONMENT_CREATE,
+        )
         specification_model = self.validate_specification(
             conda_store=self,
             namespace=namespace.name,
@@ -522,6 +560,13 @@ class CondaStore(LoggingConfigurable):
         return build.id
 
     def create_build(self, environment_id: int, specification_sha256: str):
+        environment = api.get_environment(self.db, id=environment_id)
+        self.validate_action(
+            conda_store=self,
+            namespace=environment.namespace.name,
+            action=schema.Permissions.ENVIRONMENT_UPDATE,
+        )
+
         specification = api.get_specification(self.db, specification_sha256)
         build = orm.Build(
             environment_id=environment_id, specification_id=specification.id
@@ -554,7 +599,13 @@ class CondaStore(LoggingConfigurable):
 
         return build
 
-    def update_environment_build(self, namespace, name, build_id):
+    def update_environment_build(self, namespace: str, name: str, build_id: int):
+        self.validate_action(
+            conda_store=self,
+            namespace=namespace,
+            action=schema.Permissions.ENVIRONMENT_UPDATE,
+        )
+
         build = api.get_build(self.db, build_id)
         if build is None:
             raise utils.CondaStoreError(f"build id={build_id} does not exist")
@@ -585,7 +636,6 @@ class CondaStore(LoggingConfigurable):
         tasks.task_update_environment_build.si(environment.id).apply_async()
 
     def update_environment_description(self, namespace, name, description):
-
         environment = api.get_environment(self.db, namespace=namespace, name=name)
         if environment is None:
             raise utils.CondaStoreError(
@@ -595,7 +645,13 @@ class CondaStore(LoggingConfigurable):
         environment.description = description
         self.db.commit()
 
-    def delete_namespace(self, namespace):
+    def delete_namespace(self, namespace: str):
+        self.validate_action(
+            conda_store=self,
+            namespace=namespace,
+            action=schema.Permissions.NAMESPACE_DELETE,
+        )
+
         namespace = api.get_namespace(self.db, name=namespace)
         if namespace is None:
             raise utils.CondaStoreError(f"namespace={namespace} does not exist")
@@ -615,7 +671,13 @@ class CondaStore(LoggingConfigurable):
 
         tasks.task_delete_namespace.si(namespace.id).apply_async()
 
-    def delete_environment(self, namespace, name):
+    def delete_environment(self, namespace: str, name: str):
+        self.validate_action(
+            conda_store=self,
+            namespace=namespace,
+            action=schema.Permissions.ENVIRONMENT_DELETE,
+        )
+
         environment = api.get_environment(self.db, namespace=namespace, name=name)
         if environment is None:
             raise utils.CondaStoreError(
@@ -635,8 +697,15 @@ class CondaStore(LoggingConfigurable):
 
         tasks.task_delete_environment.si(environment.id).apply_async()
 
-    def delete_build(self, build_id):
+    def delete_build(self, build_id: int):
         build = api.get_build(self.db, build_id)
+
+        self.validate_action(
+            conda_store=self,
+            namespace=build.environment.namespace.name,
+            action=schema.Permissions.BUILD_DELETE,
+        )
+
         if build.status not in [
             schema.BuildStatus.FAILED,
             schema.BuildStatus.COMPLETED,

--- a/conda-store-server/conda_store_server/app.py
+++ b/conda-store-server/conda_store_server/app.py
@@ -189,7 +189,7 @@ class CondaStore(LoggingConfigurable):
 
     storage_threshold = Integer(
         5 * 1024**3,  # 5 GB
-        help="Storage threshold of available storage to prevent conda-store builds in bytes",
+        help="Storage threshold in bytes of minimum available storage required in order to perform builds",
         config=True,
     )
 

--- a/conda-store-server/conda_store_server/schema.py
+++ b/conda-store-server/conda_store_server/schema.py
@@ -24,10 +24,12 @@ ARN_ALLOWED = f"^([{ALLOWED_CHARACTERS}*]+)/([{ALLOWED_CHARACTERS}*]+)$"
 
 
 class Permissions(enum.Enum):
+    "Permissions map to conda-store actions"
     ENVIRONMENT_CREATE = "environment:create"
     ENVIRONMENT_READ = "environment::read"
     ENVIRONMENT_UPDATE = "environment::update"
     ENVIRONMENT_DELETE = "environment::delete"
+    ENVIRONMENT_SOLVE = "environment::solve"
     BUILD_DELETE = "build::delete"
     NAMESPACE_CREATE = "namespace::create"
     NAMESPACE_READ = "namespace::read"

--- a/conda-store-server/conda_store_server/server/auth.py
+++ b/conda-store-server/conda_store_server/server/auth.py
@@ -68,6 +68,7 @@ class RBACAuthorizationBackend(LoggingConfigurable):
                 schema.Permissions.ENVIRONMENT_CREATE,
                 schema.Permissions.ENVIRONMENT_READ,
                 schema.Permissions.ENVIRONMENT_UPDATE,
+                schema.Permissions.ENVIRONMENT_SOLVE,
                 schema.Permissions.NAMESPACE_READ,
             },
             "admin": {
@@ -76,6 +77,7 @@ class RBACAuthorizationBackend(LoggingConfigurable):
                 schema.Permissions.ENVIRONMENT_DELETE,
                 schema.Permissions.ENVIRONMENT_READ,
                 schema.Permissions.ENVIRONMENT_UPDATE,
+                schema.Permissions.ENVIRONMENT_SOLVE,
                 schema.Permissions.NAMESPACE_CREATE,
                 schema.Permissions.NAMESPACE_DELETE,
                 schema.Permissions.NAMESPACE_READ,

--- a/conda-store-server/conda_store_server/server/templates/user.html
+++ b/conda-store-server/conda_store_server/server/templates/user.html
@@ -26,7 +26,12 @@
 <div class="card m-2">
     <div class="card-body">
         <h5 class="card-title">Namespace</h5>
-        <p>Your current default namespace is <span class="badge badge-light">{{ username }}</span>. The ability to create and manage namespace are controlled by permissions shown below.</p>
+        <p>Your current default namespace is <span class="badge badge-light">{{ username }}</span> with access to the following existing namespaces
+            {% for namespace in namespaces %}
+            <span class="badge badge-light">{{ namespace.name }}</span>
+            {% endfor %}
+        </p>
+        <p>The ability to create and manage namespace are controlled by permissions shown below.</p>
         <a class="btn btn-outline-success my-2 my-sm-0 mr-2 text-center" href="{{ url_for('ui_list_namespaces') }}" role="button">
             Manage Namespaces
         </a>

--- a/conda-store-server/conda_store_server/server/templates/user.html
+++ b/conda-store-server/conda_store_server/server/templates/user.html
@@ -62,6 +62,49 @@
     </div>
 </div>
 
+<div class="card m-2">
+    <div class="card-body">
+        <h5 class="card-title">Usage</h5>
+        <p>Bellow is your current usage for namespaces you have access to.</p>
+        <table class="table table-hover">
+            <thead>
+                <tr>
+                    <th scope="col">Namespace</th>
+                    <th scope="col"># Environments</th>
+                    <th scope="col"># Builds</th>
+                    <th scope="col">Total Storage</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for namespace, num_builds, num_environments, storage in namespace_usage_metrics %}
+                <tr>
+                    <td>{{ namespace }}</td>
+                    <td>{{ num_environments }}</td>
+                    <td>{{ num_builds }}</td>
+                    <td><span class="badge badge-light">{{ storage | filesizeformat(true) }}</span></td>
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    </div>
+</div>
+
+<div class="card m-2">
+    <div class="card-body">
+        <h5>System</h5>
+        <p>Bellow is system metrics.</p>
+        <ul class="list-group">
+            <li class="list-group-item">Storage Total<span class="badge badge-light">{{ system_metrics.disk_total | filesizeformat(true) }}</span></li>
+            <li class="list-group-item">Storage Free<span class="badge badge-light">{{ system_metrics.disk_free | filesizeformat(true) }}</span></li>
+            <li class="list-group-item">Storage Used<span class="badge badge-light">{{ system_metrics.disk_usage | filesizeformat(true) }}</span></li>
+        </ul>
+
+        <div class="progress">
+            <div class="progress-bar" role="progressbar" style="width: {{ (system_metrics.disk_usage / system_metrics.disk_total * 100) | round | int }}%;" aria-valuenow="{{ (system_metrics.disk_usage / system_metrics.disk_total * 100) | round | int }}" aria-valuemin="0" aria-valuemax="100">{{ (system_metrics.disk_usage / system_metrics.disk_total * 100) | round | int }}%</div>
+        </div>
+    </div>
+</div>
+
 <script>
  function setClipboard(value) {
      var tempInput = document.createElement("input");

--- a/conda-store-server/conda_store_server/server/views/ui.py
+++ b/conda-store-server/conda_store_server/server/views/ui.py
@@ -225,6 +225,10 @@ def ui_get_user(
         entity.role_bindings, authenticated=True
     )
 
+    orm_namespaces = auth.filter_namespaces(
+        entity, api.list_namespaces(conda_store.db, show_soft_deleted=False)
+    )
+
     system_metrics = api.get_system_metrics(conda_store.db)
 
     namespace_usage_metrics = auth.filter_namespaces(
@@ -234,6 +238,7 @@ def ui_get_user(
     context = {
         "request": request,
         "username": entity.primary_namespace,
+        "namespaces": orm_namespaces,
         "entity_binding_permissions": entity_binding_permissions,
         "system_metrics": system_metrics,
         "namespace_usage_metrics": namespace_usage_metrics,

--- a/conda-store-server/conda_store_server/server/views/ui.py
+++ b/conda-store-server/conda_store_server/server/views/ui.py
@@ -225,9 +225,17 @@ def ui_get_user(
         entity.role_bindings, authenticated=True
     )
 
+    system_metrics = api.get_system_metrics(conda_store.db)
+
+    namespace_usage_metrics = auth.filter_namespaces(
+        entity, api.get_namespace_metrics(conda_store.db)
+    )
+
     context = {
         "request": request,
         "username": entity.primary_namespace,
         "entity_binding_permissions": entity_binding_permissions,
+        "system_metrics": system_metrics,
+        "namespace_usage_metrics": namespace_usage_metrics,
     }
     return templates.TemplateResponse("user.html", context)

--- a/conda-store-server/conda_store_server/worker/tasks.py
+++ b/conda-store-server/conda_store_server/worker/tasks.py
@@ -45,6 +45,9 @@ class WorkerTask(Task):
 @current_app.task(base=WorkerTask, name="task_watch_paths", bind=True)
 def task_watch_paths(self):
     conda_store = self.worker.conda_store
+    conda_store.configuration.update_storage_metrics(
+        conda_store.db, conda_store.store_directory
+    )
 
     environment_paths = environment.discover_environments(self.worker.watch_paths)
     for path in environment_paths:

--- a/conda-store-server/conda_store_server/worker/tasks.py
+++ b/conda-store-server/conda_store_server/worker/tasks.py
@@ -23,7 +23,7 @@ from filelock import FileLock
 def at_start(sender, **k):
     with sender.app.connection():
         sender.app.send_task("task_update_conda_channels")
-        sender.app.send_task("task_update_storage_metrics")
+        # sender.app.send_task("task_update_storage_metrics")
         sender.app.send_task("task_watch_paths")
 
 

--- a/docs/administration.md
+++ b/docs/administration.md
@@ -100,6 +100,10 @@ validating and modifying a given specification. If there are
 validation issues with the environment ValueError with message will be
 raised.
 
+`CondaStore.validate_action` callable function taking conda_store,
+namespace, and action. If there are issues with performing the given
+action raise a CondaStoreError should be raised.
+
 `CondaStore.conda_command` is the `command` to use for creation of
 Conda environments. Currently `mamba` is the default which will
 usually result in lower peak memory usage and faster builds.
@@ -150,6 +154,9 @@ are missing.
 `CondaStore.pypi_included_packages` is a list of PyPi packages that
 if not specified within the specification dependencies will be auto
 added.
+
+`CondaStore.storage_thresold` storage threshold in bytes of minimum
+available storage required in order to perform builds.
 
 `CondaStore.database_url` is the url string for connecting to the
 database. Behind the scenes [SQLAlchemy](https://www.sqlalchemy.org/)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -59,6 +59,7 @@ def test_api_permissions_auth(testclient):
             schema.Permissions.ENVIRONMENT_READ.value,
             schema.Permissions.ENVIRONMENT_UPDATE.value,
             schema.Permissions.ENVIRONMENT_DELETE.value,
+            schema.Permissions.ENVIRONMENT_SOLVE.value,
             schema.Permissions.BUILD_DELETE.value,
             schema.Permissions.NAMESPACE_CREATE.value,
             schema.Permissions.NAMESPACE_READ.value,


### PR DESCRIPTION
Closes #440 

This ties into the current methods for conda-store validation. We have:
 - authentication/authorization (is the given entity capable of performing action on given resource)
 - validate specification which validates that the given specification complies with conda-store rules

We are adding a new validate action which at the namespace level checks if the given action is permissible. This is because validation needs to happen additionally outside of the "entity" level. Conda-Store can itself trigger new builds when watching the filesystem. 