### PR TITLE
log environment build configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
  - conda-store and conda-store-server images are now deployed to quay.io/Quansight, which has support for podman and rkt. (#455)
  - Parallel builds of conda environments (#417)
+Environment build logs now include the output 'conda info' and 'conda config --show' (#456)
 
 ### Changed
 

--- a/conda-store-server/conda_store_server/build.py
+++ b/conda-store-server/conda_store_server/build.py
@@ -163,9 +163,14 @@ def build_environment(conda_command, environment_filename, conda_prefix):
 
 def build_lock_environment(lock_filename: pathlib.Path, conda_prefix: pathlib.Path):
     return subprocess.check_output(
-        ["conda-lock", "install", "--prefix", str(conda_prefix), str(lock_filename)],
+        (
+            "conda info"
+            " && conda config --show"
+            f" && conda-lock install --prefix {conda_prefix} {lock_filename}"
+        ),
         stderr=subprocess.STDOUT,
         encoding="utf-8",
+        shell=True,
     )
 
 


### PR DESCRIPTION
Towards resolving #359. Logs the output of `conda info` and `conda config --show` along with the build command.