### PR TITLE
limit envs and storage for namespaces

### DIFF
--- a/conda-store-server/conda_store_server/api.py
+++ b/conda-store-server/conda_store_server/api.py
@@ -325,14 +325,16 @@ def get_system_metrics(db):
 
 
 def get_namespace_metrics(db):
-    return (
+
+    query = (
         db.query(
             orm.Namespace.name,
-            func.count(distinct(orm.Environment.id)),
-            func.count(distinct(orm.Build.id)),
-            func.sum(orm.Build.size),
+            func.count(distinct(orm.Environment.id)).label("env_count"),
+            func.count(distinct(orm.Build.id)).label("build_count"),
+            func.sum(orm.Build.size).label("disk_usage"),
         )
         .join(orm.Build.environment)
         .join(orm.Environment.namespace)
         .group_by(orm.Namespace.name)
     )
+    return query

--- a/conda-store-server/conda_store_server/app.py
+++ b/conda-store-server/conda_store_server/app.py
@@ -66,7 +66,7 @@ def conda_store_validate_action(
         api.get_namespace_metrics(conda_store.db)
         .filter(orm.Namespace.name == namespace)
         .filter(orm.Build.status.in_(["COMPLETED", "BUILDING"]))
-        .filter(orm.Environment.deleted_on == None) # noqa: E711
+        .filter(orm.Environment.deleted_on == None)  # noqa: E711
         .filter(orm.Environment.current_build_id.isnot(None))
         .first()
     )

--- a/conda-store-server/conda_store_server/app.py
+++ b/conda-store-server/conda_store_server/app.py
@@ -66,7 +66,7 @@ def conda_store_validate_action(
         api.get_namespace_metrics(conda_store.db)
         .filter(orm.Namespace.name == namespace)
         .filter(orm.Build.status.in_(["COMPLETED", "BUILDING"]))
-        .filter(orm.Environment.deleted_on == None)
+        .filter(orm.Environment.deleted_on == None) # noqa: E711
         .filter(orm.Environment.current_build_id.isnot(None))
         .first()
     )


### PR DESCRIPTION
Limits namespaces to a maximum storage of 10GB and a maximum number of environments to 10.

Limitations...
+  we cannot predict how much disk a build will use and so must limit env creation when the disk usage is within a defined limit (similar to the system storage validation).
+ this currently counts "completed" and "building" environments in the count... system restarts can leave a failing build in a permanently building state.
+ Disk usage is computed as the total disk usage of the current environments in a namespace: this includes repeated builds of the same environment