### PR TITLE
add pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,6 +12,7 @@ repos:
   hooks:
     - id: ruff
       exclude: "examples|tests|docs"
+      args: ["--fix"]
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.4.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,27 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
+-   repo: https://github.com/psf/black
+    rev: 22.3.0
+    hooks:
+    - id: black
+      exclude: "examples|tests|docs"
+- repo: https://github.com/charliermarsh/ruff-pre-commit
+  # Ruff version.
+  rev: 'v0.0.263'
+  hooks:
+    - id: ruff
+      exclude: "examples|tests|docs"
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.4.0
+    hooks:
+    - id: trailing-whitespace
+      files: ".*\\.py"
+    - id: check-added-large-files
+# You can add your own hooks too.
+# -   repo: local
+#     hooks:
+#     -   id: my_hook
+#         name: Some custom hook
+#         entry: ./.local_precommit_hooks/my_own_hook.sh
+#         language: script

--- a/conda-store-server/conda_store_server/server/app.py
+++ b/conda-store-server/conda_store_server/server/app.py
@@ -20,6 +20,7 @@ from traitlets import (
     Dict,
     List,
 )
+
 from traitlets.config import Application, catch_config_error
 
 from conda_store_server import storage

--- a/conda-store-server/pyproject.toml
+++ b/conda-store-server/pyproject.toml
@@ -62,8 +62,7 @@ path = "conda_store_server/__init__.py"
 
 [tool.hatch.envs.dev]
 dependencies = [
-  "black==22.3.0",
-  "ruff",
+  "pre-commit",
   "sphinx",
   "myst-parser",
   "sphinx-panels",

--- a/conda-store-server/pyproject.toml
+++ b/conda-store-server/pyproject.toml
@@ -76,12 +76,7 @@ dependencies = [
 
 [tool.hatch.envs.dev.scripts]
 lint = [
-  "black --check --diff .",
-  "ruff check .",
-]
-fmt = [
-  "black .",
-  "lint",
+  "pre-commit run --all",
 ]
 docs = "sphinx-build -b html ../docs ../docs/_build"
 unit-test = "pytest tests"

--- a/conda-store/pyproject.toml
+++ b/conda-store/pyproject.toml
@@ -49,8 +49,7 @@ path = "conda_store/__init__.py"
 
 [tool.hatch.envs.dev]
 dependencies = [
-  "black==22.3.0",
-  "ruff",
+  "pre-commit",
   "sphinx",
   "myst-parser",
   "sphinx-panels",
@@ -62,12 +61,7 @@ dependencies = [
 
 [tool.hatch.envs.dev.scripts]
 lint = [
-  "black --check --diff .",
-  "ruff check .",
-]
-fmt = [
-  "black .",
-  "lint",
+  "pre-commit run --all",
 ]
 docs = "sphinx-build -b html ../docs ../docs/_build"
 test = "pytest tests"


### PR DESCRIPTION
Resolves #475. Pre-commit runs each hook in its own isolated environment so the dependencies aren't required in the dev deps section.
