### PR TITLE
Pin SQLAlchemy <=1 .4.47

### DIFF
--- a/conda-store-server/environment-dev.yaml
+++ b/conda-store-server/environment-dev.yaml
@@ -13,7 +13,7 @@ dependencies:
   - celery
   - flower
   - redis-py
-  - sqlalchemy
+  - sqlalchemy<=1.4.47
   - psycopg2
   - pymysql
   - requests

--- a/conda-store-server/environment.yaml
+++ b/conda-store-server/environment.yaml
@@ -12,7 +12,7 @@ dependencies:
   - celery
   - flower
   - redis-py
-  - sqlalchemy
+  - sqlalchemy<=1.4.47
   - alembic
   - psycopg2
   - pymysql


### PR DESCRIPTION
Pinning SQLAlchemy to avoid solving with incompatible version >= 2 