### PR TITLE
Adding tests for fastapi server without need for integration

### DIFF
--- a/conda-store-server/conda_store_server/server/app.py
+++ b/conda-store-server/conda_store_server/server/app.py
@@ -177,7 +177,7 @@ class CondaStoreServer(Application):
         # ensure checks on redis_url
         self.conda_store.redis_url
 
-    def start(self):
+    def init_fastapi_app(self):
         def trim_slash(url):
             return url[:-1] if url.endswith("/") else url
 
@@ -298,6 +298,11 @@ class CondaStoreServer(Application):
                 name="static-storage",
             )
 
+        return app
+
+    def start(self):
+        fastapi_app = self.init_fastapi_app()
+
         self.conda_store.ensure_namespace()
         self.conda_store.ensure_conda_channels()
 
@@ -314,7 +319,7 @@ class CondaStoreServer(Application):
 
         try:
             uvicorn.run(
-                app,
+                fastapi_app,
                 host=self.address,
                 port=self.port,
                 reload=False,

--- a/conda-store-server/conda_store_server/testing.py
+++ b/conda-store-server/conda_store_server/testing.py
@@ -2,7 +2,7 @@ import typing
 import json
 import uuid
 
-from conda_store_server import schema, api, orm
+from conda_store_server import schema, api, orm, conda
 
 
 def seed_conda_store(
@@ -32,7 +32,10 @@ def seed_conda_store(
 
 
 def _create_build_packages(conda_store, build: orm.Build):
-    channel = api.ensure_conda_channel(conda_store.db, "conda-forge")
+    channel_name = conda.normalize_channel_name(
+        conda_store.conda_channel_alias, "conda-forge"
+    )
+    channel = api.ensure_conda_channel(conda_store.db, channel_name)
 
     conda_package = orm.CondaPackage(
         name=f"madeup-{uuid.uuid4()}",

--- a/conda-store-server/tests/conftest.py
+++ b/conda-store-server/tests/conftest.py
@@ -3,8 +3,10 @@ import pathlib
 
 import pytest
 import yaml
+from fastapi.testclient import TestClient
 
-from conda_store_server import app, schema, dbutil, utils
+from conda_store_server import app, schema, dbutil, utils, testing
+from conda_store_server.server import app as server_app
 
 
 @pytest.fixture
@@ -15,31 +17,112 @@ def celery_config(conda_store):
 
 
 @pytest.fixture
-def conda_store(tmp_path):
+def conda_store_config(tmp_path):
+    from traitlets.config import Config
+
+    filename = pathlib.Path(tmp_path) / "database.sqlite"
+
     with utils.chdir(tmp_path):
-        filename = pathlib.Path(tmp_path) / "database.sqlite"
+        yield Config(CondaStore=dict(database_url=f"sqlite:///{filename}"))
 
-        _conda_store = app.CondaStore()
-        _conda_store.database_url = f"sqlite:///{filename}"
-        pathlib.Path(_conda_store.store_directory).mkdir()
 
-        dbutil.upgrade(_conda_store.database_url)
+@pytest.fixture
+def conda_store_server(conda_store_config):
+    _conda_store_server = server_app.CondaStoreServer(config=conda_store_config)
+    _conda_store_server.initialize()
+    _conda_store = _conda_store_server.conda_store
 
-        _conda_store.celery_app
+    pathlib.Path(_conda_store.store_directory).mkdir(exist_ok=True)
 
-        # must import tasks after a celery app has been initialized
-        import conda_store_server.worker.tasks  # noqa
+    dbutil.upgrade(_conda_store.database_url)
 
-        # ensure that models are created
-        from celery.backends.database.session import ResultModelBase
+    _conda_store.celery_app
 
-        ResultModelBase.metadata.create_all(_conda_store.db.get_bind())
+    # must import tasks after a celery app has been initialized
+    import conda_store_server.worker.tasks  # noqa
 
-        _conda_store.configuration.update_storage_metrics(
-            _conda_store.db, _conda_store.store_directory
-        )
+    # ensure that models are created
+    from celery.backends.database.session import ResultModelBase
 
-        yield _conda_store
+    ResultModelBase.metadata.create_all(_conda_store.db.get_bind())
+
+    _conda_store.configuration.update_storage_metrics(
+        _conda_store.db, _conda_store.store_directory
+    )
+
+    yield _conda_store_server
+
+
+@pytest.fixture
+def testclient(conda_store_server):
+    return TestClient(conda_store_server.init_fastapi_app())
+
+
+@pytest.fixture
+def authenticate(testclient):
+    response = testclient.post(
+        "/login/", json={"username": "username", "password": "password"}
+    )
+    assert response.status_code == 200
+
+
+@pytest.fixture
+def seed_conda_store(conda_store):
+    testing.seed_conda_store(
+        conda_store,
+        {
+            "default": {
+                "name1": schema.CondaSpecification(
+                    name="name1",
+                    channels=["conda-forge"],
+                    dependencies=["numpy"],
+                ),
+                "name2": schema.CondaSpecification(
+                    name="name2",
+                    channels=["defaults"],
+                    dependencies=["flask"],
+                ),
+            },
+            "namespace1": {
+                "name3": schema.CondaSpecification(
+                    name="name3",
+                    channels=["bioconda"],
+                    dependencies=["numba"],
+                )
+            },
+            "namespace2": {
+                "name4": schema.CondaSpecification(
+                    name="name4",
+                    channels=["bioconda"],
+                    dependencies=["numba"],
+                )
+            },
+        },
+    )
+
+
+@pytest.fixture
+def conda_store(conda_store_config):
+    _conda_store = app.CondaStore(config=conda_store_config)
+    pathlib.Path(_conda_store.store_directory).mkdir(exist_ok=True)
+
+    dbutil.upgrade(_conda_store.database_url)
+
+    _conda_store.celery_app
+
+    # must import tasks after a celery app has been initialized
+    import conda_store_server.worker.tasks  # noqa
+
+    # ensure that models are created
+    from celery.backends.database.session import ResultModelBase
+
+    ResultModelBase.metadata.create_all(_conda_store.db.get_bind())
+
+    _conda_store.configuration.update_storage_metrics(
+        _conda_store.db, _conda_store.store_directory
+    )
+
+    yield _conda_store
 
 
 @pytest.fixture

--- a/conda-store-server/tests/conftest.py
+++ b/conda-store-server/tests/conftest.py
@@ -1,11 +1,12 @@
 import os
 import pathlib
+import datetime
 
 import pytest
 import yaml
 from fastapi.testclient import TestClient
 
-from conda_store_server import app, schema, dbutil, utils, testing
+from conda_store_server import app, schema, dbutil, utils, testing, api
 from conda_store_server.server import app as server_app
 
 
@@ -99,6 +100,13 @@ def seed_conda_store(conda_store):
             },
         },
     )
+
+    # for testing purposes make build 4 complete
+    build = api.get_build(conda_store.db, build_id=4)
+    build.started_on = datetime.datetime.utcnow()
+    build.ended_on = datetime.datetime.utcnow()
+    build.status = schema.BuildStatus.COMPLETED
+    conda_store.db.commit()
 
 
 @pytest.fixture

--- a/conda-store-server/tests/test_server.py
+++ b/conda-store-server/tests/test_server.py
@@ -569,3 +569,27 @@ def test_delete_build_auth(testclient, seed_conda_store, authenticate, celery_wo
 
     # r = schema.APIResponse.parse_obj(response.json())
     # assert r.status == schema.APIStatus.ERROR
+
+
+def test_prometheus_metrics(testclient):
+    response = testclient.get("metrics")
+    d = {
+        line.split()[0]: line.split()[1]
+        for line in response.content.decode("utf-8").split("\n")
+    }
+    assert {
+        "conda_store_disk_free",
+        "conda_store_disk_total",
+        "conda_store_disk_usage",
+    } <= d.keys()
+
+
+def test_celery_stats(testclient, celery_worker):
+    response = testclient.get("celery")
+    assert response.json().keys() == {
+        "active_tasks",
+        "availability",
+        "registered_tasks",
+        "scheduled_tasks",
+        "stats",
+    }

--- a/conda-store-server/tests/test_server.py
+++ b/conda-store-server/tests/test_server.py
@@ -1,0 +1,283 @@
+from conda_store_server import __version__, schema
+
+
+def test_api_version_unauth(testclient):
+    response = testclient.get("/api/v1/")
+    response.raise_for_status()
+
+    r = schema.APIGetStatus.parse_obj(response.json())
+    assert r.status == schema.APIStatus.OK
+    assert r.data.version == __version__
+
+
+def test_api_permissions_unauth(testclient):
+    response = testclient.get("api/v1/permission/")
+    response.raise_for_status()
+
+    r = schema.APIGetPermission.parse_obj(response.json())
+    assert r.status == schema.APIStatus.OK
+    assert r.data.authenticated is False
+    assert r.data.primary_namespace == "default"
+    assert r.data.entity_permissions == {
+        "default/*": [
+            schema.Permissions.ENVIRONMENT_READ.value,
+            schema.Permissions.NAMESPACE_READ.value,
+        ]
+    }
+
+
+def test_api_permissions_auth(testclient, authenticate):
+    response = testclient.get("api/v1/permission/")
+    response.raise_for_status()
+
+    r = schema.APIGetPermission.parse_obj(response.json())
+    assert r.status == schema.APIStatus.OK
+    assert r.data.authenticated is True
+    assert r.data.primary_namespace == "username"
+    assert r.data.entity_permissions == {
+        "*/*": sorted(
+            [
+                schema.Permissions.ENVIRONMENT_CREATE.value,
+                schema.Permissions.ENVIRONMENT_READ.value,
+                schema.Permissions.ENVIRONMENT_UPDATE.value,
+                schema.Permissions.ENVIRONMENT_DELETE.value,
+                schema.Permissions.ENVIRONMENT_SOLVE.value,
+                schema.Permissions.BUILD_DELETE.value,
+                schema.Permissions.NAMESPACE_CREATE.value,
+                schema.Permissions.NAMESPACE_READ.value,
+                schema.Permissions.NAMESPACE_DELETE.value,
+            ]
+        ),
+        "default/*": sorted(
+            [
+                schema.Permissions.ENVIRONMENT_READ.value,
+                schema.Permissions.NAMESPACE_READ.value,
+            ]
+        ),
+        "filesystem/*": sorted(
+            [
+                schema.Permissions.ENVIRONMENT_READ.value,
+                schema.Permissions.NAMESPACE_READ.value,
+            ]
+        ),
+    }
+
+
+def test_api_list_namespace_unauth(testclient, seed_conda_store):
+    response = testclient.get("api/v1/namespace")
+    response.raise_for_status()
+
+    r = schema.APIListNamespace.parse_obj(response.json())
+    assert r.status == schema.APIStatus.OK
+    # by default unauth only has access to the default namespace
+    assert len(r.data) == 1
+    assert r.data[0].name == "default"
+
+
+def test_api_list_namespace_auth(testclient, seed_conda_store, authenticate):
+    response = testclient.get("api/v1/namespace")
+    response.raise_for_status()
+
+    r = schema.APIListNamespace.parse_obj(response.json())
+    assert r.status == schema.APIStatus.OK
+    assert sorted([_.name for _ in r.data]) == ["default", "namespace1", "namespace2"]
+
+
+def test_api_get_namespace_unauth(testclient, seed_conda_store):
+    response = testclient.get("api/v1/namespace/default")
+    response.raise_for_status()
+
+    r = schema.APIGetNamespace.parse_obj(response.json())
+    assert r.status == schema.APIStatus.OK
+    assert r.data.name == "default"
+
+
+def test_api_get_namespace_unauth_no_exist(testclient, seed_conda_store):
+    response = testclient.get("api/v1/namespace/namespace1")
+    assert response.status_code == 403
+
+    r = schema.APIResponse.parse_obj(response.json())
+    assert r.status == schema.APIStatus.ERROR
+
+
+def test_api_get_namespace_auth(testclient, seed_conda_store, authenticate):
+    response = testclient.get("api/v1/namespace/namespace1")
+    response.raise_for_status()
+
+    r = schema.APIGetNamespace.parse_obj(response.json())
+    assert r.status == schema.APIStatus.OK
+    assert r.data.name == "namespace1"
+
+
+def test_api_get_namespace_auth_no_exist(testclient, seed_conda_store, authenticate):
+    response = testclient.get("api/v1/namespace/wrong")
+
+    assert response.status_code == 404
+    r = schema.APIResponse.parse_obj(response.json())
+    assert r.status == schema.APIStatus.ERROR
+
+
+def test_api_list_environments_unauth(testclient, seed_conda_store):
+    response = testclient.get("api/v1/environment")
+    response.raise_for_status()
+
+    r = schema.APIListEnvironment.parse_obj(response.json())
+    assert r.status == schema.APIStatus.OK
+    assert sorted([_.name for _ in r.data]) == ["name1", "name2"]
+
+
+def test_api_list_environments_auth(testclient, seed_conda_store, authenticate):
+    response = testclient.get("api/v1/environment")
+    response.raise_for_status()
+
+    r = schema.APIListEnvironment.parse_obj(response.json())
+    assert r.status == schema.APIStatus.OK
+    assert sorted([_.name for _ in r.data]) == ["name1", "name2", "name3", "name4"]
+
+
+def test_api_get_environment_unauth(testclient, seed_conda_store):
+    response = testclient.get("api/v1/environment/namespace1/name3")
+    assert response.status_code == 403
+
+    r = schema.APIResponse.parse_obj(response.json())
+    assert r.status == schema.APIStatus.ERROR
+
+
+def test_api_get_environment_auth_existing(testclient, seed_conda_store, authenticate):
+    response = testclient.get("api/v1/environment/namespace1/name3")
+    response.raise_for_status()
+
+    r = schema.APIGetEnvironment.parse_obj(response.json())
+    assert r.status == schema.APIStatus.OK
+    assert r.data.namespace.name == "namespace1"
+    assert r.data.name == "name3"
+
+
+def test_api_get_environment_auth_not_existing(
+    testclient, seed_conda_store, authenticate
+):
+    response = testclient.get("api/v1/environment/namespace1/wrong")
+    assert response.status_code == 404
+
+    r = schema.APIResponse.parse_obj(response.json())
+    assert r.status == schema.APIStatus.ERROR
+
+
+def test_api_list_builds_unauth(testclient, seed_conda_store):
+    response = testclient.get("api/v1/build")
+    response.raise_for_status()
+
+    r = schema.APIListBuild.parse_obj(response.json())
+    assert r.status == schema.APIStatus.OK
+    assert len(r.data) == 2
+
+
+def test_api_list_builds_auth(testclient, seed_conda_store, authenticate):
+    response = testclient.get("api/v1/build")
+    response.raise_for_status()
+
+    r = schema.APIListBuild.parse_obj(response.json())
+    assert r.status == schema.APIStatus.OK
+    assert len(r.data) == 4
+
+
+def test_api_get_build_one_unauth(testclient, seed_conda_store):
+    response = testclient.get("api/v1/build/3")  # namespace1/name3
+    assert response.status_code == 403
+
+    r = schema.APIResponse.parse_obj(response.json())
+    assert r.status == schema.APIStatus.ERROR
+
+
+def test_api_get_build_one_auth(testclient, seed_conda_store, authenticate):
+    response = testclient.get("api/v1/build/3")
+    response.raise_for_status()
+
+    r = schema.APIGetBuild.parse_obj(response.json())
+    assert r.status == schema.APIStatus.OK
+    assert r.data.id == 3
+    assert r.data.specification.name == "name3"
+    assert r.data.status == schema.BuildStatus.QUEUED.value
+
+
+def test_api_get_build_one_unauth_packages(testclient, seed_conda_store):
+    response = testclient.get("api/v1/build/3/packages")
+    assert response.status_code == 403
+
+    r = schema.APIResponse.parse_obj(response.json())
+    assert r.status == schema.APIStatus.ERROR
+
+
+def test_api_get_build_one_auth_packages(testclient, seed_conda_store, authenticate):
+    response = testclient.get("api/v1/build/3/packages")
+    response.raise_for_status()
+
+    r = schema.APIListCondaPackage.parse_obj(response.json())
+    assert r.status == schema.APIStatus.OK
+    assert len(r.data) == 1
+
+
+def test_api_get_build_auth_packages_no_exist(
+    testclient, seed_conda_store, authenticate
+):
+    response = testclient.get("api/v1/build/101010101/packages")
+    assert response.status_code == 404
+
+    r = schema.APIResponse.parse_obj(response.json())
+    assert r.status == schema.APIStatus.ERROR
+
+
+def test_api_get_build_one_unauth_logs(testclient, seed_conda_store):
+    response = testclient.get("api/v1/build/3/logs")
+    assert response.status_code == 403
+
+    r = schema.APIResponse.parse_obj(response.json())
+    assert r.status == schema.APIStatus.ERROR
+
+
+def test_api_get_build_one_auth_logs(testclient, seed_conda_store, authenticate):
+    response = testclient.get("api/v1/build/3/logs")
+    response.raise_for_status()
+
+    logs = response.content.decode("utf-8")
+    assert "fake logs" in logs
+
+
+def test_api_get_build_auth_logs_no_exist(testclient, seed_conda_store, authenticate):
+    response = testclient.get("api/v1/build/10101010101/logs")
+    assert response.status_code == 404
+
+
+def test_api_get_build_one_unauth_yaml(testclient, seed_conda_store):
+    response = testclient.get("api/v1/build/3/yaml/")
+    assert response.status_code == 403
+
+
+def test_api_get_build_one_auth_yaml(testclient, seed_conda_store, authenticate):
+    response = testclient.get("api/v1/build/3/yaml/")
+    response.raise_for_status()
+
+    environment_yaml = response.content.decode("utf-8")
+    assert "name:" in environment_yaml
+    assert "channels:" in environment_yaml
+    assert "dependencies:" in environment_yaml
+
+
+def test_api_get_build_two_auth(testclient, seed_conda_store, authenticate):
+    response = testclient.get("api/v1/build/1010101010101")
+    response.status_code == 404
+
+    r = schema.APIResponse.parse_obj(response.json())
+    assert r.status == schema.APIStatus.ERROR
+
+
+def test_api_list_conda_channels_unauth(testclient):
+    response = testclient.get("api/v1/channel")
+    response.raise_for_status()
+
+    r = schema.APIListCondaChannel.parse_obj(response.json())
+    assert r.status == schema.APIStatus.OK
+    api_channels = set(_.name for _ in r.data)
+    assert api_channels == {
+        "https://conda.anaconda.org/conda-forge",
+    }

--- a/conda-store-server/tests/test_testing.py
+++ b/conda-store-server/tests/test_testing.py
@@ -30,3 +30,4 @@ def test_testing_initialize_database(conda_store):
     assert len(api.list_environments(conda_store.db).all()) == 3
     assert len(api.list_builds(conda_store.db).all()) == 3
     assert len(api.list_solves(conda_store.db).all()) == 3
+    assert len(api.list_conda_packages(conda_store.db).all()) == 3


### PR DESCRIPTION
Making it such that conda-store-server can run what used to be the integration tests. 