### PR TITLE
Adding an api method for getting usage data for namespaces

### DIFF
--- a/conda-store-server/conda_store_server/schema.py
+++ b/conda-store-server/conda_store_server/schema.py
@@ -596,3 +596,8 @@ class APIGetSetting(APIResponse):
 # PUT /api/v1/setting/*/*
 class APIPutSetting(APIResponse):
     pass
+
+
+# GET /api/v1/usage/
+class APIGetUsage(APIResponse):
+    data: Dict[str, Dict[str, Any]]

--- a/conda-store-server/conda_store_server/server/views/api.py
+++ b/conda-store-server/conda_store_server/server/views/api.py
@@ -161,6 +161,35 @@ def api_get_permissions(
     }
 
 
+@router_api.get(
+    "/usage/",
+    response_model=schema.APIGetUsage,
+)
+def api_get_usage(
+    request: Request,
+    conda_store=Depends(dependencies.get_conda_store),
+    auth=Depends(dependencies.get_auth),
+    entity=Depends(dependencies.get_entity),
+):
+    namespace_usage_metrics = auth.filter_namespaces(
+        entity, api.get_namespace_metrics(conda_store.db)
+    )
+
+    data = {}
+    for namespace, num_environments, num_builds, storage in namespace_usage_metrics:
+        data[namespace] = {
+            "num_environments": num_environments,
+            "num_builds": num_builds,
+            "storage": storage,
+        }
+
+    return {
+        "status": "ok",
+        "data": data,
+        "message": None,
+    }
+
+
 @router_api.post(
     "/token/",
     response_model=schema.APIPostToken,

--- a/conda-store-server/tests/test_server.py
+++ b/conda-store-server/tests/test_server.py
@@ -70,6 +70,22 @@ def test_api_permissions_auth(testclient, authenticate):
     }
 
 
+def test_get_usage_unauth(testclient):
+    response = testclient.get("/api/v1/usage/")
+    response.raise_for_status()
+
+    r = schema.APIPutSetting.parse_obj(response.json())
+    assert r.status == schema.APIStatus.OK
+
+
+def test_get_usage_auth(testclient, authenticate):
+    response = testclient.get("/api/v1/usage/")
+    response.raise_for_status()
+
+    r = schema.APIPutSetting.parse_obj(response.json())
+    assert r.status == schema.APIStatus.OK
+
+
 def test_api_list_namespace_unauth(testclient, seed_conda_store):
     response = testclient.get("api/v1/namespace")
     response.raise_for_status()


### PR DESCRIPTION
Currently there is a way to get this information in the UI but wanted a way to get these usage statistics via the api for clients.