### PR TITLE
Change the tests when using sqlite to not check threads (celery + traitlets + fastapi) are doing weird things

### DIFF
--- a/conda-store-server/tests/conftest.py
+++ b/conda-store-server/tests/conftest.py
@@ -24,7 +24,7 @@ def conda_store_config(tmp_path):
     filename = pathlib.Path(tmp_path) / "database.sqlite"
 
     with utils.chdir(tmp_path):
-        yield Config(CondaStore=dict(database_url=f"sqlite:///{filename}"))
+        yield Config(CondaStore=dict(database_url=f"sqlite:///{filename}?check_same_thread=False"))
 
 
 @pytest.fixture


### PR DESCRIPTION
See https://github.com/Quansight/conda-store/actions/runs/5613636006/job/15210071085 for examples