### PR TITLE
API : update a namespace's metadata and role mappings

### DIFF
--- a/conda-store-server/conda_store_server/api.py
+++ b/conda-store-server/conda_store_server/api.py
@@ -1,4 +1,4 @@
-from typing import List, Dict, Any, Optional
+from typing import List, Dict, Any, Optional, Union
 import re
 
 from sqlalchemy import func, null, or_, distinct
@@ -50,8 +50,8 @@ def create_namespace(db, name: str):
 def update_namespace(
     db,
     name: str,
-    metadata_: Optional[Dict] | None = None,
-    role_mappings: Optional[Dict[str, List[str]]] | None = None,
+    metadata_: Union[Optional[Dict], None] = None,
+    role_mappings: Union[Optional[Dict[str, List[str]]], None] = None,
 ):
 
     namespace = get_namespace(db, name)

--- a/conda-store-server/conda_store_server/orm.py
+++ b/conda-store-server/conda_store_server/orm.py
@@ -36,6 +36,7 @@ from conda_store_server.conda import download_repodata
 import re
 import logging
 
+
 logger = logging.getLogger("orm")
 
 Base = declarative_base()
@@ -82,6 +83,13 @@ class NamespaceRoleMapping(Base):
             raise ValueError(f"invalid entity={entity}")
 
         return entity
+
+    @validates("role")
+    def validate_role(self, key, role):
+        if role not in ["admin", "viewer", "developer"]:
+            raise ValueError(f"invalid entity={role}")
+
+        return role
 
 
 class Specification(Base):

--- a/conda-store-server/conda_store_server/schema.py
+++ b/conda-store-server/conda_store_server/schema.py
@@ -34,6 +34,7 @@ class Permissions(enum.Enum):
     BUILD_DELETE = "build::delete"
     NAMESPACE_CREATE = "namespace::create"
     NAMESPACE_READ = "namespace::read"
+    NAMESPACE_UPDATE = "namespace::update"
     NAMESPACE_DELETE = "namespace::delete"
     SETTING_READ = "setting::read"
     SETTING_UPDATE = "setting::update"

--- a/conda-store-server/conda_store_server/schema.py
+++ b/conda-store-server/conda_store_server/schema.py
@@ -36,6 +36,9 @@ class Permissions(enum.Enum):
     NAMESPACE_READ = "namespace::read"
     NAMESPACE_UPDATE = "namespace::update"
     NAMESPACE_DELETE = "namespace::delete"
+    NAMESPACE_ROLE_MAPPING_READ = "namespace-role-mapping::read"
+    NAMESPACE_ROLE_MAPPING_CREATE = "namespace-role-mapping::create"
+    NAMESPACE_ROLE_MAPPING_DELETE = "namespace-role-mapping::delete"
     SETTING_READ = "setting::read"
     SETTING_UPDATE = "setting::update"
 

--- a/conda-store-server/conda_store_server/server/auth.py
+++ b/conda-store-server/conda_store_server/server/auth.py
@@ -84,6 +84,7 @@ class RBACAuthorizationBackend(LoggingConfigurable):
                 schema.Permissions.NAMESPACE_CREATE,
                 schema.Permissions.NAMESPACE_DELETE,
                 schema.Permissions.NAMESPACE_READ,
+                schema.Permissions.NAMESPACE_UPDATE,
                 schema.Permissions.SETTING_READ,
                 schema.Permissions.SETTING_UPDATE,
             },

--- a/conda-store-server/conda_store_server/server/auth.py
+++ b/conda-store-server/conda_store_server/server/auth.py
@@ -85,6 +85,8 @@ class RBACAuthorizationBackend(LoggingConfigurable):
                 schema.Permissions.NAMESPACE_DELETE,
                 schema.Permissions.NAMESPACE_READ,
                 schema.Permissions.NAMESPACE_UPDATE,
+                schema.Permissions.NAMESPACE_ROLE_MAPPING_CREATE,
+                schema.Permissions.NAMESPACE_ROLE_MAPPING_DELETE,
                 schema.Permissions.SETTING_READ,
                 schema.Permissions.SETTING_UPDATE,
             },

--- a/conda-store-server/conda_store_server/server/views/api.py
+++ b/conda-store-server/conda_store_server/server/views/api.py
@@ -321,7 +321,14 @@ def api_update_namespace(
 ):
 
     auth.authorize_request(
-        request, namespace, {Permissions.NAMESPACE_UPDATE}, require=True
+        request,
+        namespace,
+        {
+            Permissions.NAMESPACE_UPDATE,
+            Permissions.NAMESPACE_ROLE_MAPPING_CREATE,
+            Permissions.NAMESPACE_ROLE_MAPPING_DELETE,
+        },
+        require=True,
     )
 
     namespace_orm = api.get_namespace(conda_store.db, namespace)

--- a/conda-store-server/conda_store_server/server/views/api.py
+++ b/conda-store-server/conda_store_server/server/views/api.py
@@ -1,4 +1,4 @@
-from typing import List, Dict, Optional, Any
+from typing import List, Dict, Optional, Any, Union
 import datetime
 
 import pydantic
@@ -314,8 +314,8 @@ def api_create_namespace(
 def api_update_namespace(
     namespace: str,
     request: Request,
-    metadata: Optional[Dict | List] | None = None,
-    role_mappings: Optional[Dict[str, List[str]]] | None = None,
+    metadata: Union[Optional[Dict | List], None] = None,
+    role_mappings: Union[Optional[Dict[str, List[str]]], None] = None,
     conda_store=Depends(dependencies.get_conda_store),
     auth=Depends(dependencies.get_auth),
 ):

--- a/conda-store-server/tests/test_server.py
+++ b/conda-store-server/tests/test_server.py
@@ -51,6 +51,7 @@ def test_api_permissions_auth(testclient, authenticate):
                 schema.Permissions.NAMESPACE_CREATE.value,
                 schema.Permissions.NAMESPACE_READ.value,
                 schema.Permissions.NAMESPACE_DELETE.value,
+                schema.Permissions.NAMESPACE_UPDATE.value,
                 schema.Permissions.SETTING_READ.value,
                 schema.Permissions.SETTING_UPDATE.value,
             ]

--- a/conda-store-server/tests/test_server.py
+++ b/conda-store-server/tests/test_server.py
@@ -52,6 +52,8 @@ def test_api_permissions_auth(testclient, authenticate):
                 schema.Permissions.NAMESPACE_READ.value,
                 schema.Permissions.NAMESPACE_DELETE.value,
                 schema.Permissions.NAMESPACE_UPDATE.value,
+                schema.Permissions.NAMESPACE_ROLE_MAPPING_CREATE.value,
+                schema.Permissions.NAMESPACE_ROLE_MAPPING_DELETE.value,
                 schema.Permissions.SETTING_READ.value,
                 schema.Permissions.SETTING_UPDATE.value,
             ]

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -64,6 +64,7 @@ def test_api_permissions_auth(testclient):
             schema.Permissions.NAMESPACE_CREATE.value,
             schema.Permissions.NAMESPACE_READ.value,
             schema.Permissions.NAMESPACE_DELETE.value,
+            schema.Permissions.NAMESPACE_UPDATE.value,
             schema.Permissions.SETTING_READ.value,
             schema.Permissions.SETTING_UPDATE.value,
         ]),

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -65,6 +65,8 @@ def test_api_permissions_auth(testclient):
             schema.Permissions.NAMESPACE_READ.value,
             schema.Permissions.NAMESPACE_DELETE.value,
             schema.Permissions.NAMESPACE_UPDATE.value,
+            schema.Permissions.NAMESPACE_ROLE_MAPPING_CREATE.value,
+            schema.Permissions.NAMESPACE_ROLE_MAPPING_DELETE.value,
             schema.Permissions.SETTING_READ.value,
             schema.Permissions.SETTING_UPDATE.value,
         ]),


### PR DESCRIPTION
This PR adds a new API endpoint to update a namespace's role mappings and metadata.

the `PUT /conda-store/api/v1/namespace/{namespace}/` endpoint takes a JSON payload to update the metadata, the role mappings, or both.

- update the metadata : 
```json
{
  "metadata": {"my_key":"my_value"}
}
``` 

- update the role mappings : 
```json
{
  "role_mappings": {
    "admin/admin": ["admin", "viewer", "developer"],
    "admin/*": ["viewer"],
    "demo/*": ["developer"]
  }
}
```

- update both :
```json
{
  "metadata": {"my_key":"my_value"},
  "role_mappings": {
    "admin/admin": ["admin"],
    "admin/*": ["viewer"],
    "demo/*": ["developer"]
  }
}
```

@costrouc tell me if that works for you or if you'd see another approach or pattern.

According to the original issue #491 : 
> - namespace update rest api method that uses the namespace update
> - create, list, delete for adding namespace role mappings. I think you should only be able to edit namespace role mappings if you have namespace::update permissions. If you have namespace::read it should be sufficient to view members.

We now need to add an endpoint to list the role mappings. 
