### PR TITLE
Allow setting a subdomain cookie for conda-store

### DIFF
--- a/conda-store-server/conda_store_server/server/auth.py
+++ b/conda-store-server/conda_store_server/server/auth.py
@@ -269,6 +269,13 @@ class Authentication(LoggingConfigurable):
         config=True,
     )
 
+    cookie_domain = Unicode(
+        None,
+        help="Use when wanting to set a subdomain wide cookie. For example setting this to `example.com` would allow the cookie to be valid for `example.com` along with `*.example.com`.",
+        allow_none=True,
+        config=True,
+    )
+
     authentication_backend = Type(
         AuthenticationBackend,
         help="class for authentication implementation",
@@ -429,6 +436,7 @@ form.addEventListener('submit', loginHandler);
             self.authentication.encrypt_token(authentication_token),
             httponly=True,
             samesite="strict",
+            domain=self.cookie_domain,
             # set cookie to expire at same time as jwt
             max_age=(authentication_token.exp - datetime.datetime.utcnow()).seconds,
         )

--- a/docs/administration.md
+++ b/docs/administration.md
@@ -331,6 +331,8 @@ bindings that an authenticated user assumes.
 `Authentication.cookie_name` is the name for the browser cookie used
 to authenticate users.
 
+`Authentication.cookie_domain` use when wanting to set a subdomain wide cookie. For example setting this to `example.com` would allow the cookie to be valid for `example.com` along with `*.example.com`.
+
 `Authentication.authentication_backend` is the class to use for
 authentication logic. The default is `AuthenticationBackend` and will
 likely not need to change.


### PR DESCRIPTION
This allow the setting of a cookie for `Authentication.cookie_domain = "example.com"`. This allows the cookie to be valid for `example.com` along with `*.example.com`